### PR TITLE
Unify all `fit_*` and `eval_*` methods by introducing 3 `EquationOfStateTarget`

### DIFF
--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -15,11 +15,11 @@ using InteractiveUtils
 using Parameters
 using StaticArrays: FieldVector, Size
 
+using EquationsOfState.Targets
+
 import StaticArrays: similar_type
 
-export eval_energy,
-    eval_pressure,
-    eval_bulk_modulus,
+export calculate,
     EquationOfState,
     FiniteStrainEquationOfState,
     PolynomialEquationOfState,
@@ -211,54 +211,54 @@ BreenanStacey(v0, b0, γ0) = BreenanStacey(v0, b0, γ0, 0)
 # ============================================================================ #
 #                               Energy evaluation                              #
 # ============================================================================ #
-eval_energy(eos::EquationOfState, vec::AbstractVector{<: Real}) = map(x->eval_energy(eos, x), vec)
-function eval_energy(eos::Birch, v::Real)
+calculate(::Type{EnergyTarget}, eos::EquationOfState, vec::AbstractVector{<: Real}) = map(x->calculate(EnergyTarget, eos, x), vec)
+function calculate(::Type{EnergyTarget}, eos::Birch, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = (v0 / v)^(2 / 3) - 1
     xi = 9 / 16 * b0 * v0 * x^2
     return e0 + 2 * xi + (bp0 - 4) * xi * x
 end
-function eval_energy(eos::Murnaghan, v::Real)
+function calculate(::Type{EnergyTarget}, eos::Murnaghan, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = bp0 - 1
     y = (v0 / v)^bp0
     return e0 + b0 / bp0 * v * (y / x + 1) - v0 * b0 / x
 end
-function eval_energy(eos::BirchMurnaghan2nd, v::Real)
+function calculate(::Type{EnergyTarget}, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0, e0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return e0 + 9 / 2 * b0 * v0 * f^2
 end
-function eval_energy(eos::BirchMurnaghan3rd, v::Real)
+function calculate(::Type{EnergyTarget}, eos::BirchMurnaghan3rd, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     eta = (v0 / v)^(1 / 3)
     xi = eta^2 - 1
     return e0 + 9 / 16 * b0 * v0 * xi^2 * (6 + bp0 * xi - 4eta^2)
 end
-function eval_energy(eos::BirchMurnaghan4th, v::Real)
+function calculate(::Type{EnergyTarget}, eos::BirchMurnaghan4th, v::Real)
     @unpack v0, b0, bp0, bpp0, e0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     h = b0 * bpp0 + bp0^2
     return e0 + 3 / 8 * v0 * b0 * f^2 * ((9h - 63bp0 + 143) * f^2 + 12(bp0 - 4) * f + 12)
 end
-function eval_energy(eos::PoirierTarantola2nd, v::Real)
+function calculate(::Type{EnergyTarget}, eos::PoirierTarantola2nd, v::Real)
     @unpack v0, b0, e0 = eos
 
     return e0 + b0 / 2 * v0 * log(v / v0)^(2 / 3)
 end
-function eval_energy(eos::PoirierTarantola3rd, v::Real)
+function calculate(::Type{EnergyTarget}, eos::PoirierTarantola3rd, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = -3log(x)
     return e0 + b0 / 6 * v0 * xi^2 * ((bp0 - 2) * xi + 3)
 end
-function eval_energy(eos::PoirierTarantola4th, v::Real)
+function calculate(::Type{EnergyTarget}, eos::PoirierTarantola4th, v::Real)
     @unpack v0, b0, bp0, bpp0, e0 = eos
 
     x = (v / v0)^(1 / 3)
@@ -266,14 +266,14 @@ function eval_energy(eos::PoirierTarantola4th, v::Real)
     h = b0 * bpp0 + bp0^2
     return e0 + b0 / 24v0 * xi^2 * ((h + 3bp0 + 3) * xi^2 + 4(bp0 + 2) * xi + 12)
 end
-function eval_energy(eos::Vinet, v::Real)
+function calculate(::Type{EnergyTarget}, eos::Vinet, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = 3 / 2 * (bp0 - 1)
     return e0 + 9b0 * v0 / xi^2 * (1 + (xi * (1 - x) - 1) * exp(xi * (1 - x)))
 end
-function eval_energy(eos::AntonSchmidt, v::Real)
+function calculate(::Type{EnergyTarget}, eos::AntonSchmidt, v::Real)
     @unpack v0, β, n, e∞ = eos
 
     x = v / v0
@@ -286,52 +286,52 @@ end
 # ============================================================================ #
 #                              Pressure evaluation                             #
 # ============================================================================ #
-eval_pressure(eos::EquationOfState, vec::AbstractVector{<: Real}) = map(x->eval_pressure(eos, x), vec)
-function eval_pressure(eos::Birch, v::Real)
+calculate(::Type{PressureTarget}, eos::EquationOfState, vec::AbstractVector{<: Real}) = map(x->calculate(PressureTarget, eos, x), vec)
+function calculate(::Type{PressureTarget}, eos::Birch, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = v0 / v
     xi = x^(2 / 3) - 1
     return 3 / 8 * b0 * x^(5 / 3) * xi * (4 + 3(bp0 - 4) * xi)
 end
-function eval_pressure(eos::Murnaghan, v::Real)
+function calculate(::Type{PressureTarget}, eos::Murnaghan, v::Real)
     @unpack v0, b0, bp0 = eos
 
     return b0 / bp0 * ((v0 / v)^bp0 - 1)
 end
-function eval_pressure(eos::BirchMurnaghan2nd, v::Real)
+function calculate(::Type{PressureTarget}, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return 3b0 * f * (1 + 2f)^(5 / 2)
 end
-function eval_pressure(eos::BirchMurnaghan3rd, v::Real)
+function calculate(::Type{PressureTarget}, eos::BirchMurnaghan3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     eta = (v0 / v)^(1 / 3)
     return 3 / 2 * b0 * (eta^7 - eta^5) * (1 + 3 / 4 * (bp0 - 4) * (eta^2 - 1))
 end
-function eval_pressure(eos::BirchMurnaghan4th, v::Real)
+function calculate(::Type{PressureTarget}, eos::BirchMurnaghan4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     h = b0 * bpp0 + bp0^2
     return b0 / 2 * (2f + 1)^(5 / 2) * ((9h - 63bp0 + 143) * f^2 + 9(bp0 - 4) * f + 6)
 end
-function eval_pressure(eos::PoirierTarantola2nd, v::Real)
+function calculate(::Type{PressureTarget}, eos::PoirierTarantola2nd, v::Real)
     @unpack v0, b0 = eos
 
     x = (v / v0)^(1 / 3)
     return -b0 / x * log(x)
 end
-function eval_pressure(eos::PoirierTarantola3rd, v::Real)
+function calculate(::Type{PressureTarget}, eos::PoirierTarantola3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = v / v0
     xi = log(x)
     return -b0 * xi / 2x * ((bp0 - 2) * xi - 2)
 end
-function eval_pressure(eos::PoirierTarantola4th, v::Real)
+function calculate(::Type{PressureTarget}, eos::PoirierTarantola4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     x = (v / v0)^(1 / 3)
@@ -339,20 +339,20 @@ function eval_pressure(eos::PoirierTarantola4th, v::Real)
     h = b0 * bpp0 + bp0^2
     return -b0 * xi / 6 / x * ((h + 3bp0 + 3) * xi^2 + 3(bp0 + 6) * xi + 6)
 end
-function eval_pressure(eos::Vinet, v::Real)
+function calculate(::Type{PressureTarget}, eos::Vinet, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = 3 / 2 * (bp0 - 1)
     return 3b0 / x^2 * (1 - x) * exp(xi * (1 - x))
 end
-function eval_pressure(eos::AntonSchmidt, v::Real)
+function calculate(::Type{PressureTarget}, eos::AntonSchmidt, v::Real)
     @unpack v0, β, n = eos
 
     x = v / v0
     return -β * x^n * log(x)
 end
-function eval_pressure(eos::BreenanStacey, v::Real)
+function calculate(::Type{PressureTarget}, eos::BreenanStacey, v::Real)
     @unpack v0, b0, γ0 = eos
 
     x = v0 / v
@@ -364,40 +364,40 @@ end
 # ============================================================================ #
 #                            Bulk modulus evaluation                           #
 # ============================================================================ #
-eval_bulk_modulus(eos::EquationOfState, vec::AbstractVector{<: Real}) = map(x->eval_bulk_modulus(eos, x), vec)
-function eval_bulk_modulus(eos::BirchMurnaghan2nd, v::Real)
+calculate(::Type{BulkModulusTarget}, eos::EquationOfState, vec::AbstractVector{<: Real}) = map(x->calculate(BulkModulusTarget, eos, x), vec)
+function calculate(::Type{BulkModulusTarget}, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return b0 * (7f + 1) * (2f + 1)^(5 / 2)
 end
-function eval_bulk_modulus(eos::BirchMurnaghan3rd, v::Real)
+function calculate(::Type{BulkModulusTarget}, eos::BirchMurnaghan3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return b0 / 2 * (2f + 1)^(5 / 2) * ((27f^2 + 6f) * (bp0 - 4) - 4f + 2)
 end
-function eval_bulk_modulus(eos::BirchMurnaghan4th, v::Real)
+function calculate(::Type{BulkModulusTarget}, eos::BirchMurnaghan4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     h = b0 * bpp0 + bp0^2
     return b0 / 6 * (2f + 1)^(5 / 2) * ((99h - 693bp0 + 1573) * f^3 + (27h - 108bp0 + 105) * f^2 + 6f * (3bp0 - 5) + 6)
 end
-function eval_bulk_modulus(eos::PoirierTarantola2nd, v::Real)
+function calculate(::Type{BulkModulusTarget}, eos::PoirierTarantola2nd, v::Real)
     @unpack v0, b0 = eos
 
     x = (v / v0)^(1 / 3)
     return b0 / x * (1 - log(x))
 end
-function eval_bulk_modulus(eos::PoirierTarantola3rd, v::Real)
+function calculate(::Type{BulkModulusTarget}, eos::PoirierTarantola3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = v / v0
     xi = log(x)
     return -b0 / 2x * (((bp0 - 2) * xi + 2 - 2bp0) * xi + 2)
 end
-function eval_bulk_modulus(eos::PoirierTarantola4th, v::Real)
+function calculate(::Type{BulkModulusTarget}, eos::PoirierTarantola4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     x = (v / v0)^(1 / 3)
@@ -405,14 +405,14 @@ function eval_bulk_modulus(eos::PoirierTarantola4th, v::Real)
     h = b0 * bpp0 + bp0^2
     return -b0 / (6x) * ((h + 3bp0 + 3) * xi^3 - 3xi^2 * (h + 2bp0 + 1) - 6xi * (bp0 + 1) - 6)
 end
-function eval_bulk_modulus(eos::Vinet, v::Real)
+function calculate(::Type{BulkModulusTarget}, eos::Vinet, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = 3 / 2 * (bp0 - 1)
     return -b0 / (2x^2) * (3x * (x - 1) * (bp0 - 1) + 2(x - 2)) * exp(-xi * (x - 1))
 end
-function eval_bulk_modulus(eos::AntonSchmidt, v::Real)
+function calculate(::Type{BulkModulusTarget}, eos::AntonSchmidt, v::Real)
     @unpack v0, β, n = eos
 
     x = v / v0

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -211,6 +211,7 @@ BreenanStacey(v0, b0, γ0) = BreenanStacey(v0, b0, γ0, 0)
 # ============================================================================ #
 #                               Energy evaluation                              #
 # ============================================================================ #
+calculate(::Type{EnergyTarget}, eos::EquationOfState) = v -> calculate(EnergyTarget, eos, v)
 function calculate(::Type{EnergyTarget}, eos::Birch, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
@@ -285,6 +286,7 @@ end
 # ============================================================================ #
 #                              Pressure evaluation                             #
 # ============================================================================ #
+calculate(::Type{PressureTarget}, eos::EquationOfState) = v -> calculate(PressureTarget, eos, v)
 function calculate(::Type{PressureTarget}, eos::Birch, v::Real)
     @unpack v0, b0, bp0 = eos
 
@@ -362,6 +364,7 @@ end
 # ============================================================================ #
 #                            Bulk modulus evaluation                           #
 # ============================================================================ #
+calculate(::Type{BulkModulusTarget}, eos::EquationOfState) = v -> calculate(BulkModulusTarget, eos, v)
 function calculate(::Type{BulkModulusTarget}, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0 = eos
 

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -211,7 +211,6 @@ BreenanStacey(v0, b0, γ0) = BreenanStacey(v0, b0, γ0, 0)
 # ============================================================================ #
 #                               Energy evaluation                              #
 # ============================================================================ #
-calculate(::Type{EnergyTarget}, eos::EquationOfState, vec::AbstractVector{<: Real}) = map(x->calculate(EnergyTarget, eos, x), vec)
 function calculate(::Type{EnergyTarget}, eos::Birch, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
@@ -286,7 +285,6 @@ end
 # ============================================================================ #
 #                              Pressure evaluation                             #
 # ============================================================================ #
-calculate(::Type{PressureTarget}, eos::EquationOfState, vec::AbstractVector{<: Real}) = map(x->calculate(PressureTarget, eos, x), vec)
 function calculate(::Type{PressureTarget}, eos::Birch, v::Real)
     @unpack v0, b0, bp0 = eos
 
@@ -364,7 +362,6 @@ end
 # ============================================================================ #
 #                            Bulk modulus evaluation                           #
 # ============================================================================ #
-calculate(::Type{BulkModulusTarget}, eos::EquationOfState, vec::AbstractVector{<: Real}) = map(x->calculate(BulkModulusTarget, eos, x), vec)
 function calculate(::Type{BulkModulusTarget}, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0 = eos
 

--- a/src/EquationsOfState.jl
+++ b/src/EquationsOfState.jl
@@ -2,6 +2,7 @@ module EquationsOfState
 
 using Reexport
 
+include("Targets.jl")
 include("Collections.jl")
 include("NonlinearFitting.jl")
 include("FiniteStrains.jl")

--- a/src/EquationsOfState.jl
+++ b/src/EquationsOfState.jl
@@ -7,7 +7,7 @@ include("Collections.jl")
 include("NonlinearFitting.jl")
 include("FiniteStrains.jl")
 include("LinearFitting.jl")
-include("volume.jl")
+include("NumericallyFindVolume.jl")
 
 @reexport using .Collections
 

--- a/src/EquationsOfState.jl
+++ b/src/EquationsOfState.jl
@@ -9,6 +9,6 @@ include("FiniteStrains.jl")
 include("LinearFitting.jl")
 include("NumericallyFindVolume.jl")
 
-@reexport using .Collections
+@reexport using .Targets
 
 end # module

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -19,7 +19,7 @@ using EquationsOfState.Collections
 export lsqfit
 
 function lsqfit(A::Type{<: EquationOfStateTarget}, eos::E, xdata::Vector{T}, ydata::Vector{T}; debug::Bool = false, kwargs...) where {T <: AbstractFloat,E <: EquationOfState{T}}
-    model(x, p) = calculate(A, E(p), x)
+    model(x, p) = map(calculate(A, E(p)), x)
     fitted = curve_fit(model, xdata, ydata, collect(eos); kwargs...)
     debug ? fitted : E(fitted.param)
 end  # function lsqfit

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -13,32 +13,19 @@ module NonlinearFitting
 
 using LsqFit: curve_fit
 
+using EquationsOfState.Targets
 using EquationsOfState.Collections
 
-export fit_energy,
-    fit_pressure,
-    fit_bulk_modulus
+export lsqfit
 
-function lsqfit(f::Function, eos::E, xdata::Vector{T}, ydata::Vector{T}; debug::Bool = false, kwargs...) where {T <: AbstractFloat,E <: EquationOfState{T}}
-    model(x, p) = f(E(p), x)
+function lsqfit(A::Type{<: EquationOfStateTarget}, eos::E, xdata::Vector{T}, ydata::Vector{T}; debug::Bool = false, kwargs...) where {T <: AbstractFloat,E <: EquationOfState{T}}
+    model(x, p) = calculate(A, E(p), x)
     fitted = curve_fit(model, xdata, ydata, collect(eos); kwargs...)
     debug ? fitted : E(fitted.param)
 end  # function lsqfit
-function lsqfit(f::Function, eos::E, xdata::X, ydata::Y; kwargs...) where {E <: EquationOfState,X <: AbstractVector,Y <: AbstractVector}
+function lsqfit(A::Type{<: EquationOfStateTarget}, eos::E, xdata::X, ydata::Y; kwargs...) where {E <: EquationOfState,X <: AbstractVector,Y <: AbstractVector}
     T = promote_type(eltype(eos), eltype(xdata), eltype(ydata), Float64)
-    lsqfit(f, convert(similar_type(E, T), eos), convert(Vector{T}, xdata), convert(Vector{T}, ydata); kwargs...)
+    lsqfit(A, convert(similar_type(E, T), eos), convert(Vector{T}, xdata), convert(Vector{T}, ydata); kwargs...)
 end  # function lsqfit
-
-fit_energy(eos::EquationOfState, xdata::AbstractVector, ydata::AbstractVector; kwargs...) = lsqfit(eval_energy, eos, xdata, ydata; kwargs...)
-
-function fit_pressure(eos::EquationOfState, xdata::AbstractVector, ydata::AbstractVector; silent::Bool = true, kwargs...)
-    silent || @info "Fitting pressure... The parameter `e0 = $(eos.e0)` is not used and will be kept as input."
-    lsqfit(eval_pressure, eos, xdata, ydata; kwargs...)
-end
-
-function fit_bulk_modulus(eos::EquationOfState, xdata::AbstractVector, ydata::AbstractVector; silent::Bool = true, kwargs...)
-    silent || @info "Fitting bulk modulus... The parameter `e0 = $(eos.e0)` is not used and will be kept as input."
-    lsqfit(eval_bulk_modulus, eos, xdata, ydata; kwargs...)
-end
 
 end

--- a/src/NumericallyFindVolume.jl
+++ b/src/NumericallyFindVolume.jl
@@ -1,9 +1,16 @@
-#=
-volume:
-- Julia version: 1.0
-- Author: singularitti
-- Date: 2019-08-06
-=#
+"""
+# module NumericallyFindVolume
+
+
+
+# Examples
+
+```jldoctest
+julia>
+```
+"""
+module NumericallyFindVolume
+
 using IntervalRootFinding
 
 using EquationsOfState.Targets
@@ -16,3 +23,5 @@ function find_volume(T::Type{<: EquationOfStateTarget}, eos::EquationOfState, y:
     solutions = roots(f, interval, method)
     length(solutions) != 1 ? error("Multiple roots find!") : return first(solutions)
 end # function find_volume
+
+end

--- a/src/Targets.jl
+++ b/src/Targets.jl
@@ -1,0 +1,22 @@
+"""
+# module Targets
+
+
+
+# Examples
+
+```jldoctest
+julia>
+```
+"""
+module Targets
+
+export EquationOfStateTarget, EnergyTarget, PressureTarget, BulkModulusTarget
+
+abstract type EquationOfStateTarget end
+
+struct EnergyTarget <: EquationOfStateTarget end
+struct PressureTarget <: EquationOfStateTarget end
+struct BulkModulusTarget <: EquationOfStateTarget end
+
+end

--- a/src/volume.jl
+++ b/src/volume.jl
@@ -6,17 +6,13 @@ volume:
 =#
 using IntervalRootFinding
 
+using EquationsOfState.Targets
 using EquationsOfState.Collections
 
 export find_volume
 
-# function find_volume(eos, energies, interval, method)
-#     f(v) = eval_energy(eos, v)
-#     solutions = roots(f, interval, method)
-#     length(solutions) != 1 ? error("Multiple roots find!") : return first(solutions)
-# end # function find_volume
-function find_volume(eos, pressures, interval, method)
-    f(v) = eval_pressure(eos, v)
+function find_volume(T::Type{<: EquationOfStateTarget}, eos, y, interval, method)
+    f = v -> calculate(T, eos, v)
     solutions = roots(f, interval, method)
     length(solutions) != 1 ? error("Multiple roots find!") : return first(solutions)
 end # function find_volume

--- a/src/volume.jl
+++ b/src/volume.jl
@@ -12,7 +12,7 @@ using EquationsOfState.Collections
 export find_volume
 
 function find_volume(T::Type{<: EquationOfStateTarget}, eos, y, interval, method)
-    f = v -> calculate(T, eos, v)
+    f = v -> calculate(T, eos, v) - y
     solutions = roots(f, interval, method)
     length(solutions) != 1 ? error("Multiple roots find!") : return first(solutions)
 end # function find_volume

--- a/src/volume.jl
+++ b/src/volume.jl
@@ -11,7 +11,7 @@ using EquationsOfState.Collections
 
 export find_volume
 
-function find_volume(T::Type{<: EquationOfStateTarget}, eos, y, interval, method)
+function find_volume(T::Type{<: EquationOfStateTarget}, eos::EquationOfState, y::Real, interval, method)
     f = v -> calculate(T, eos, v) - y
     solutions = roots(f, interval, method)
     length(solutions) != 1 ? error("Multiple roots find!") : return first(solutions)

--- a/test/CollectionsTests.jl
+++ b/test/CollectionsTests.jl
@@ -8,7 +8,7 @@ module CollectionsTests
 
 using Test
 
-using EquationsOfState
+using EquationsOfState.Collections
 
 @testset "Test EOS promotion" begin
     @test typeof(Birch(1, 2, 3.0, 0)) == Birch{Float64}

--- a/test/NonlinearFittingTests.jl
+++ b/test/NonlinearFittingTests.jl
@@ -13,26 +13,26 @@ using EquationsOfState.NonlinearFitting
 
 @testset "Test fitting energy with different element types" begin
     result = Birch(0.0057009512119028044, 103.58772269057364, -144.45152457521132, -40.31992619868024)
-    @test isapprox(fit_energy(Birch(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]), result; atol = 1e-5)
-    @test isapprox(fit_energy(Birch(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]), result; atol = 1e-5)
-    @test isapprox(fit_energy(Birch(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]), result; atol = 1e-5)
-    @test isapprox(fit_energy(Birch(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]), result; atol = 1e-5)
+    @test isapprox(lsqfit(EnergyTarget, Birch(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]), result; atol = 1e-5)
+    @test isapprox(lsqfit(EnergyTarget, Birch(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]), result; atol = 1e-5)
+    @test isapprox(lsqfit(EnergyTarget, Birch(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]), result; atol = 1e-5)
+    @test isapprox(lsqfit(EnergyTarget, Birch(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]), result; atol = 1e-5)
 end
 
 @testset "Test fitting pressure with different element types" begin
     result = Birch(1.1024687826597717, 29.30861698140365, 12.689089871112746, 0.0)
-    @test isapprox(fit_pressure(Birch(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-6)
-    @test isapprox(fit_pressure(Birch(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-6)
-    @test isapprox(fit_pressure(Birch(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]; silent = false), result; atol = 1e-6)
-    @test isapprox(fit_pressure(Birch(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-6)
+    @test isapprox(lsqfit(PressureTarget, Birch(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-6)
+    @test isapprox(lsqfit(PressureTarget, Birch(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-6)
+    @test isapprox(lsqfit(PressureTarget, Birch(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]; silent = false), result; atol = 1e-6)
+    @test isapprox(lsqfit(PressureTarget, Birch(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-6)
 end
 
 @testset "Test fitting bulk modulus with different element types" begin
     result = BirchMurnaghan3rd(7.218928431312577, 5.007900469653902, 4.06037725509478, 0.0)
-    @test isapprox(fit_bulk_modulus(BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-5)
-    @test isapprox(fit_bulk_modulus(BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-5)
-    @test isapprox(fit_bulk_modulus(BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]; silent = false), result; atol = 1e-5)
-    @test isapprox(fit_bulk_modulus(BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-5)
+    @test isapprox(lsqfit(BulkModulusTarget, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-5)
+    @test isapprox(lsqfit(BulkModulusTarget, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-5)
+    @test isapprox(lsqfit(BulkModulusTarget, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]; silent = false), result; atol = 1e-5)
+    @test isapprox(lsqfit(BulkModulusTarget, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-5)
 end
 
 # Data in the following tests are from
@@ -62,11 +62,11 @@ end
         -10.1197772808, -9.99504030111, -9.86535084973,
         -9.73155247952
     ]
-    @test isapprox(fit_energy(Birch(40, 0.5, 4, 0), volumes, energies), Birch(40.98926572870838, 0.5369258244952931, 4.178644231838501, -10.8428039082307))
-    @test isapprox(fit_energy(BirchMurnaghan3rd(40, 0.5, 4, 0), volumes, energies), BirchMurnaghan3rd(40.98926572528106, 0.5369258245417454, 4.178644235500821, -10.842803908240892))
-    @test isapprox(fit_energy(Murnaghan(41, 0.5, 4, 0), volumes, energies), Murnaghan(41.13757930387086, 0.5144967693786603, 3.9123862262572264, -10.836794514626673))
-    @test isapprox(fit_energy(PoirierTarantola3rd(41, 0.5, 4, 0), volumes, energies), PoirierTarantola3rd(40.86770643373908, 0.5667729960804602, 4.331688936974368, -10.851486685041658))
-    @test isapprox(fit_energy(Vinet(41, 0.5, 4, 0), volumes, energies), Vinet(40.916875663779784, 0.5493839425156859, 4.3051929654936885, -10.846160810560756))
+    @test isapprox(lsqfit(EnergyTarget, Birch(40, 0.5, 4, 0), volumes, energies), Birch(40.98926572870838, 0.5369258244952931, 4.178644231838501, -10.8428039082307))
+    @test isapprox(lsqfit(EnergyTarget, BirchMurnaghan3rd(40, 0.5, 4, 0), volumes, energies), BirchMurnaghan3rd(40.98926572528106, 0.5369258245417454, 4.178644235500821, -10.842803908240892))
+    @test isapprox(lsqfit(EnergyTarget, Murnaghan(41, 0.5, 4, 0), volumes, energies), Murnaghan(41.13757930387086, 0.5144967693786603, 3.9123862262572264, -10.836794514626673))
+    @test isapprox(lsqfit(EnergyTarget, PoirierTarantola3rd(41, 0.5, 4, 0), volumes, energies), PoirierTarantola3rd(40.86770643373908, 0.5667729960804602, 4.331688936974368, -10.851486685041658))
+    @test isapprox(lsqfit(EnergyTarget, Vinet(41, 0.5, 4, 0), volumes, energies), Vinet(40.916875663779784, 0.5493839425156859, 4.3051929654936885, -10.846160810560756))
     # 'deltafactor': {'b0': 0.5369258245611414,
 #             'b1': 4.178644231924639,
 #             'e0': -10.842803908299294,
@@ -151,7 +151,7 @@ end
         -1.594410995
     ]
 
-    fitted_eos = fit_energy(Vinet(23, 0.5, 4, -2), mp153_volumes, mp153_energies)
+    fitted_eos = lsqfit(EnergyTarget, Vinet(23, 0.5, 4, -2), mp153_volumes, mp153_energies)
     @test isapprox(fitted_eos, Vinet(22.95764559358769, 0.2257091141420788, 4.060543387224629, -1.5944292606251582))
     @test isapprox(calculate(EnergyTarget, fitted_eos, mp153_volumes), mp153_known_energies_vinet; atol = 1e-5)
 end
@@ -229,7 +229,7 @@ end
         -5.118654229
     ]
 
-    fitted_eos = fit_energy(Vinet(20, 0.5, 4, -5), mp149_volumes, mp149_energies)
+    fitted_eos = lsqfit(EnergyTarget, Vinet(20, 0.5, 4, -5), mp149_volumes, mp149_energies)
     @test isapprox(fitted_eos, Vinet(20.446696754873944, 0.5516638521306302, 4.324373909783161, -5.424963389876503))
     @test isapprox(calculate(EnergyTarget, fitted_eos, mp149_volumes), mp149_known_energies_vinet; atol = 1e-5)
 end
@@ -307,7 +307,7 @@ end
         -7.897414664
     ]
 
-    fitted_eos = fit_energy(Vinet(17, 0.5, 4, -7), mp72_volumes, mp72_energies)
+    fitted_eos = lsqfit(EnergyTarget, Vinet(17, 0.5, 4, -7), mp72_volumes, mp72_energies)
     @test isapprox(fitted_eos, Vinet(17.13223026131245, 0.7029766224730147, 3.6388077563621812, -7.897414959124461))
     @test isapprox(calculate(EnergyTarget, fitted_eos, mp72_volumes), mp72_known_energies_vinet; atol = 1e-5)
 end
@@ -378,13 +378,13 @@ end
     ]
     volumes = data[:, 1]  # unit: bohr^3
     energies = data[:, 2]  # unit: Rydberg
-    @test fit_energy(BirchMurnaghan3rd(224, 0.0006, 4, -323), volumes, energies) ≈ BirchMurnaghan3rd(224.444565, 0.00062506191050572675, 3.740369, -323.417714)
-    @test isapprox(fit_energy(BirchMurnaghan4th(224, 0.0006, 4, -5460, -323), volumes, energies),
+    @test lsqfit(EnergyTarget, BirchMurnaghan3rd(224, 0.0006, 4, -323), volumes, energies) ≈ BirchMurnaghan3rd(224.444565, 0.00062506191050572675, 3.740369, -323.417714)
+    @test isapprox(lsqfit(EnergyTarget, BirchMurnaghan4th(224, 0.0006, 4, -5460, -323), volumes, energies),
                               BirchMurnaghan4th(224.457562, 0.00062293812247621543, 3.730992, -5322.69673452213, -323.417712); atol = 1e-3)
-    @test isapprox(fit_energy(Murnaghan(224, 0.006, 4, -323), volumes, energies),
+    @test isapprox(lsqfit(EnergyTarget, Murnaghan(224, 0.006, 4, -323), volumes, energies),
                               Murnaghan(224.501825, 0.00060479524074699499, 3.723835, -323.417686); atol = 1e-5)
-    @test isapprox(fit_energy(PoirierTarantola3rd(100, 0.0006, 3.7, -323), volumes, energies), PoirierTarantola3rd(224.509208, 0.000635892264159838, 3.690448, -323.41773); atol = 1e-5)
-    # @test fit_energy(PoirierTarantola4th(220, 0.0006, 3.7, -5500, -323), volumes, energies; lower = Float64[220, 0, 3, -6000, -400], upper = Float64[300, 0.01, 5, -5000, -300]) ≈ PoirierTarantola4th(224.430182, 0.0006232241765069493, 3.758360, -5493.859729817176, -323.417712)
+    @test isapprox(lsqfit(EnergyTarget, PoirierTarantola3rd(100, 0.0006, 3.7, -323), volumes, energies), PoirierTarantola3rd(224.509208, 0.000635892264159838, 3.690448, -323.41773); atol = 1e-5)
+    # @test lsqfit(EnergyTarget, PoirierTarantola4th(220, 0.0006, 3.7, -5500, -323), volumes, energies; lower = Float64[220, 0, 3, -6000, -400], upper = Float64[300, 0.01, 5, -5000, -300]) ≈ PoirierTarantola4th(224.430182, 0.0006232241765069493, 3.758360, -5493.859729817176, -323.417712)
 end
 
 end

--- a/test/NonlinearFittingTests.jl
+++ b/test/NonlinearFittingTests.jl
@@ -8,7 +8,8 @@ module NonlinearFittingTests
 
 using Test
 
-using EquationsOfState
+using EquationsOfState.Targets
+using EquationsOfState.Collections
 using EquationsOfState.NonlinearFitting
 
 @testset "Test fitting energy with different element types" begin

--- a/test/NonlinearFittingTests.jl
+++ b/test/NonlinearFittingTests.jl
@@ -22,18 +22,18 @@ end
 
 @testset "Test fitting pressure with different element types" begin
     result = Birch(1.1024687826597717, 29.30861698140365, 12.689089871112746, 0.0)
-    @test isapprox(lsqfit(PressureTarget, Birch(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-6)
-    @test isapprox(lsqfit(PressureTarget, Birch(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-6)
-    @test isapprox(lsqfit(PressureTarget, Birch(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]; silent = false), result; atol = 1e-6)
-    @test isapprox(lsqfit(PressureTarget, Birch(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-6)
+    @test isapprox(lsqfit(PressureTarget, Birch(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]), result; atol = 1e-6)
+    @test isapprox(lsqfit(PressureTarget, Birch(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]), result; atol = 1e-6)
+    @test isapprox(lsqfit(PressureTarget, Birch(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]), result; atol = 1e-6)
+    @test isapprox(lsqfit(PressureTarget, Birch(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]), result; atol = 1e-6)
 end
 
 @testset "Test fitting bulk modulus with different element types" begin
     result = BirchMurnaghan3rd(7.218928431312577, 5.007900469653902, 4.06037725509478, 0.0)
-    @test isapprox(lsqfit(BulkModulusTarget, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-5)
-    @test isapprox(lsqfit(BulkModulusTarget, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-5)
-    @test isapprox(lsqfit(BulkModulusTarget, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]; silent = false), result; atol = 1e-5)
-    @test isapprox(lsqfit(BulkModulusTarget, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]; silent = false), result; atol = 1e-5)
+    @test isapprox(lsqfit(BulkModulusTarget, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]), result; atol = 1e-5)
+    @test isapprox(lsqfit(BulkModulusTarget, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]), result; atol = 1e-5)
+    @test isapprox(lsqfit(BulkModulusTarget, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]), result; atol = 1e-5)
+    @test isapprox(lsqfit(BulkModulusTarget, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]), result; atol = 1e-5)
 end
 
 # Data in the following tests are from
@@ -154,7 +154,7 @@ end
 
     fitted_eos = lsqfit(EnergyTarget, Vinet(23, 0.5, 4, -2), mp153_volumes, mp153_energies)
     @test isapprox(fitted_eos, Vinet(22.95764559358769, 0.2257091141420788, 4.060543387224629, -1.5944292606251582))
-    @test isapprox(calculate(EnergyTarget, fitted_eos, mp153_volumes), mp153_known_energies_vinet; atol = 1e-5)
+    @test isapprox(map(calculate(EnergyTarget, fitted_eos), mp153_volumes), mp153_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "Test Si dataset" begin
@@ -232,7 +232,7 @@ end
 
     fitted_eos = lsqfit(EnergyTarget, Vinet(20, 0.5, 4, -5), mp149_volumes, mp149_energies)
     @test isapprox(fitted_eos, Vinet(20.446696754873944, 0.5516638521306302, 4.324373909783161, -5.424963389876503))
-    @test isapprox(calculate(EnergyTarget, fitted_eos, mp149_volumes), mp149_known_energies_vinet; atol = 1e-5)
+    @test isapprox(map(calculate(EnergyTarget, fitted_eos), mp149_volumes), mp149_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "Test Ti dataset" begin
@@ -310,7 +310,7 @@ end
 
     fitted_eos = lsqfit(EnergyTarget, Vinet(17, 0.5, 4, -7), mp72_volumes, mp72_energies)
     @test isapprox(fitted_eos, Vinet(17.13223026131245, 0.7029766224730147, 3.6388077563621812, -7.897414959124461))
-    @test isapprox(calculate(EnergyTarget, fitted_eos, mp72_volumes), mp72_known_energies_vinet; atol = 1e-5)
+    @test isapprox(map(calculate(EnergyTarget, fitted_eos), mp72_volumes), mp72_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "`w2k-lda-na.dat` from `Gibbs2`" begin

--- a/test/NonlinearFittingTests.jl
+++ b/test/NonlinearFittingTests.jl
@@ -153,7 +153,7 @@ end
 
     fitted_eos = fit_energy(Vinet(23, 0.5, 4, -2), mp153_volumes, mp153_energies)
     @test isapprox(fitted_eos, Vinet(22.95764559358769, 0.2257091141420788, 4.060543387224629, -1.5944292606251582))
-    @test isapprox(eval_energy(fitted_eos, mp153_volumes), mp153_known_energies_vinet; atol = 1e-5)
+    @test isapprox(calculate(EnergyTarget, fitted_eos, mp153_volumes), mp153_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "Test Si dataset" begin
@@ -231,7 +231,7 @@ end
 
     fitted_eos = fit_energy(Vinet(20, 0.5, 4, -5), mp149_volumes, mp149_energies)
     @test isapprox(fitted_eos, Vinet(20.446696754873944, 0.5516638521306302, 4.324373909783161, -5.424963389876503))
-    @test isapprox(eval_energy(fitted_eos, mp149_volumes), mp149_known_energies_vinet; atol = 1e-5)
+    @test isapprox(calculate(EnergyTarget, fitted_eos, mp149_volumes), mp149_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "Test Ti dataset" begin
@@ -309,7 +309,7 @@ end
 
     fitted_eos = fit_energy(Vinet(17, 0.5, 4, -7), mp72_volumes, mp72_energies)
     @test isapprox(fitted_eos, Vinet(17.13223026131245, 0.7029766224730147, 3.6388077563621812, -7.897414959124461))
-    @test isapprox(eval_energy(fitted_eos, mp72_volumes), mp72_known_energies_vinet; atol = 1e-5)
+    @test isapprox(calculate(EnergyTarget, fitted_eos, mp72_volumes), mp72_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "`w2k-lda-na.dat` from `Gibbs2`" begin


### PR DESCRIPTION
1. Unify `eval_energy`, `eval_pressure` and `eval_bulk_modulus` to a single function `calculate`
2. Unify `fit_energy`, `fit_pressure` and `fit_bulk_modulus` to a single function `lsqfit`
3. Unify `find_volume` methods (3 unimplemented) to 1 method