### PR TITLE
Big change: Refactor a lot of behaviors

### DIFF
--- a/docs/src/Collections.md
+++ b/docs/src/Collections.md
@@ -150,15 +150,15 @@ The $E(V)$ relation of equations of state are listed as below:
 ## Public interfaces
 
 ```@docs
-apply(::Type{EnergyForm}, eos::EquationOfState)
-apply(::Type{EnergyForm}, eos::Murnaghan, v::Real)
-apply(::Type{EnergyForm}, eos::BirchMurnaghan2nd, v::Real)
-apply(::Type{EnergyForm}, eos::BirchMurnaghan3rd, v::Real)
-apply(::Type{EnergyForm}, eos::BirchMurnaghan4th, v::Real)
+apply(::EnergyForm, eos::EquationOfState)
+apply(::EnergyForm, eos::Murnaghan, v::Real)
+apply(::EnergyForm, eos::BirchMurnaghan2nd, v::Real)
+apply(::EnergyForm, eos::BirchMurnaghan3rd, v::Real)
+apply(::EnergyForm, eos::BirchMurnaghan4th, v::Real)
 
-apply(::Type{PressureForm}, eos::EquationOfState)
+apply(::PressureForm, eos::EquationOfState)
 
-apply(::Type{BulkModulusForm}, eos::EquationOfState)
+apply(::BulkModulusForm, eos::EquationOfState)
 ```
 
 

--- a/docs/src/Collections.md
+++ b/docs/src/Collections.md
@@ -156,7 +156,7 @@ calculate(::Type{EnergyForm}, eos::BirchMurnaghan2nd, v::Real)
 calculate(::Type{EnergyForm}, eos::BirchMurnaghan3rd, v::Real)
 calculate(::Type{EnergyForm}, eos::BirchMurnaghan4th, v::Real)
 
-calculate(::Type{PressureRelation}, eos::EquationOfState)
+calculate(::Type{PressureForm}, eos::EquationOfState)
 
 calculate(::Type{BulkModulusRelation}, eos::EquationOfState)
 ```

--- a/docs/src/Collections.md
+++ b/docs/src/Collections.md
@@ -150,15 +150,15 @@ The $E(V)$ relation of equations of state are listed as below:
 ## Public interfaces
 
 ```@docs
-calculate(::Type{EnergyForm}, eos::EquationOfState)
-calculate(::Type{EnergyForm}, eos::Murnaghan, v::Real)
-calculate(::Type{EnergyForm}, eos::BirchMurnaghan2nd, v::Real)
-calculate(::Type{EnergyForm}, eos::BirchMurnaghan3rd, v::Real)
-calculate(::Type{EnergyForm}, eos::BirchMurnaghan4th, v::Real)
+apply(::Type{EnergyForm}, eos::EquationOfState)
+apply(::Type{EnergyForm}, eos::Murnaghan, v::Real)
+apply(::Type{EnergyForm}, eos::BirchMurnaghan2nd, v::Real)
+apply(::Type{EnergyForm}, eos::BirchMurnaghan3rd, v::Real)
+apply(::Type{EnergyForm}, eos::BirchMurnaghan4th, v::Real)
 
-calculate(::Type{PressureForm}, eos::EquationOfState)
+apply(::Type{PressureForm}, eos::EquationOfState)
 
-calculate(::Type{BulkModulusForm}, eos::EquationOfState)
+apply(::Type{BulkModulusForm}, eos::EquationOfState)
 ```
 
 

--- a/docs/src/Collections.md
+++ b/docs/src/Collections.md
@@ -150,11 +150,11 @@ The $E(V)$ relation of equations of state are listed as below:
 ## Public interfaces
 
 ```@docs
-calculate(::Type{EnergyRelation}, eos::EquationOfState)
-calculate(::Type{EnergyRelation}, eos::Murnaghan, v::Real)
-calculate(::Type{EnergyRelation}, eos::BirchMurnaghan2nd, v::Real)
-calculate(::Type{EnergyRelation}, eos::BirchMurnaghan3rd, v::Real)
-calculate(::Type{EnergyRelation}, eos::BirchMurnaghan4th, v::Real)
+calculate(::Type{EnergyForm}, eos::EquationOfState)
+calculate(::Type{EnergyForm}, eos::Murnaghan, v::Real)
+calculate(::Type{EnergyForm}, eos::BirchMurnaghan2nd, v::Real)
+calculate(::Type{EnergyForm}, eos::BirchMurnaghan3rd, v::Real)
+calculate(::Type{EnergyForm}, eos::BirchMurnaghan4th, v::Real)
 
 calculate(::Type{PressureRelation}, eos::EquationOfState)
 

--- a/docs/src/Collections.md
+++ b/docs/src/Collections.md
@@ -158,7 +158,7 @@ calculate(::Type{EnergyForm}, eos::BirchMurnaghan4th, v::Real)
 
 calculate(::Type{PressureForm}, eos::EquationOfState)
 
-calculate(::Type{BulkModulusRelation}, eos::EquationOfState)
+calculate(::Type{BulkModulusForm}, eos::EquationOfState)
 ```
 
 

--- a/docs/src/NonlinearFitting.md
+++ b/docs/src/NonlinearFitting.md
@@ -90,7 +90,7 @@ Then 4 different equations of state will be fitted.
 ## Public interfaces
 
 ```@docs
-lsqfit(::Type{<:EquationOfStateRelation}, eos::E, xdata::X, ydata::Y; debug = false, kwargs...) where {E<:EquationOfState,X<:AbstractVector,Y<:AbstractVector}
+lsqfit(::Type{<:EquationOfStateForm}, eos::E, xdata::X, ydata::Y; debug = false, kwargs...) where {E<:EquationOfState,X<:AbstractVector,Y<:AbstractVector}
 ```
 
 

--- a/docs/src/NonlinearFitting.md
+++ b/docs/src/NonlinearFitting.md
@@ -80,10 +80,10 @@ energies = [
     -9.73155247952
 ]
 
-lsqfit(EnergyRelation, BirchMurnaghan3rd(40, 0.5, 4, 0), volumes, energies)
-lsqfit(EnergyRelation, Murnaghan(41, 0.5, 4, 0), volumes, energies)
-lsqfit(EnergyRelation, PoirierTarantola3rd(41, 0.5, 4, 0), volumes, energies)
-lsqfit(EnergyRelation, Vinet(41, 0.5, 4, 0), volumes, energies)
+lsqfit(EnergyForm, BirchMurnaghan3rd(40, 0.5, 4, 0), volumes, energies)
+lsqfit(EnergyForm, Murnaghan(41, 0.5, 4, 0), volumes, energies)
+lsqfit(EnergyForm, PoirierTarantola3rd(41, 0.5, 4, 0), volumes, energies)
+lsqfit(EnergyForm, Vinet(41, 0.5, 4, 0), volumes, energies)
 ```
 Then 4 different equations of state will be fitted.
 

--- a/docs/src/NonlinearFitting.md
+++ b/docs/src/NonlinearFitting.md
@@ -80,10 +80,10 @@ energies = [
     -9.73155247952
 ]
 
-lsqfit(EnergyForm, BirchMurnaghan3rd(40, 0.5, 4, 0), volumes, energies)
-lsqfit(EnergyForm, Murnaghan(41, 0.5, 4, 0), volumes, energies)
-lsqfit(EnergyForm, PoirierTarantola3rd(41, 0.5, 4, 0), volumes, energies)
-lsqfit(EnergyForm, Vinet(41, 0.5, 4, 0), volumes, energies)
+lsqfit(EnergyForm(), BirchMurnaghan3rd(40, 0.5, 4, 0), volumes, energies)
+lsqfit(EnergyForm(), Murnaghan(41, 0.5, 4, 0), volumes, energies)
+lsqfit(EnergyForm(), PoirierTarantola3rd(41, 0.5, 4, 0), volumes, energies)
+lsqfit(EnergyForm(), Vinet(41, 0.5, 4, 0), volumes, energies)
 ```
 Then 4 different equations of state will be fitted.
 

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -284,7 +284,7 @@ BreenanStacey(v0, b0, γ0) = BreenanStacey(v0, b0, γ0, 0)
 #                               Energy evaluation                              #
 # ============================================================================ #
 """
-    apply(EnergyForm, eos::EquationOfState)
+    apply(EnergyForm(), eos::EquationOfState)
 
 Return a function that can take a volume as a parameter, suitable for batch-applying.
 
@@ -292,7 +292,7 @@ Return a function that can take a volume as a parameter, suitable for batch-appl
 ```jldoctest
 julia> using EquationsOfState, EquationsOfState.Collections
 
-julia> f = apply(EnergyForm, Vinet(1, 2, 3));
+julia> f = apply(EnergyForm(), Vinet(1, 2, 3));
 
 julia> map(f, 1:1:10)
 10-element Array{Float64,1}:
@@ -308,13 +308,13 @@ julia> map(f, 1:1:10)
  1.7203642945516917
 ```
 """
-apply(::Type{EnergyForm}, eos::EquationOfState) = v -> apply(EnergyForm, eos, v)
+apply(::EnergyForm, eos::EquationOfState) = v -> apply(EnergyForm(), eos, v)
 """
     apply(EnergyForm, eos::Murnaghan, v::Real)
 
 Return the energy of a `Murnaghan` equation of state on volume `v`.
 """
-function apply(::Type{EnergyForm}, eos::Murnaghan, v::Real)
+function apply(::EnergyForm, eos::Murnaghan, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = bp0 - 1
@@ -326,7 +326,7 @@ end
 
 Return the energy of a `BirchMurnaghan2nd` equation of state on volume `v`.
 """
-function apply(::Type{EnergyForm}, eos::BirchMurnaghan2nd, v::Real)
+function apply(::EnergyForm, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0, e0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
@@ -337,7 +337,7 @@ end
 
 Return the energy of a `BirchMurnaghan3rd` equation of state on volume `v`.
 """
-function apply(::Type{EnergyForm}, eos::BirchMurnaghan3rd, v::Real)
+function apply(::EnergyForm, eos::BirchMurnaghan3rd, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     eta = (v0 / v)^(1 / 3)
@@ -349,26 +349,26 @@ end
 
 Return the energy of a `BirchMurnaghan4th` equation of state on volume `v`.
 """
-function apply(::Type{EnergyForm}, eos::BirchMurnaghan4th, v::Real)
+function apply(::EnergyForm, eos::BirchMurnaghan4th, v::Real)
     @unpack v0, b0, bp0, bpp0, e0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     h = b0 * bpp0 + bp0^2
     return e0 + 3 / 8 * v0 * b0 * f^2 * ((9h - 63bp0 + 143) * f^2 + 12(bp0 - 4) * f + 12)
 end
-function apply(::Type{EnergyForm}, eos::PoirierTarantola2nd, v::Real)
+function apply(::EnergyForm, eos::PoirierTarantola2nd, v::Real)
     @unpack v0, b0, e0 = eos
 
     return e0 + b0 / 2 * v0 * log(v / v0)^(2 / 3)
 end
-function apply(::Type{EnergyForm}, eos::PoirierTarantola3rd, v::Real)
+function apply(::EnergyForm, eos::PoirierTarantola3rd, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = -3log(x)
     return e0 + b0 / 6 * v0 * xi^2 * ((bp0 - 2) * xi + 3)
 end
-function apply(::Type{EnergyForm}, eos::PoirierTarantola4th, v::Real)
+function apply(::EnergyForm, eos::PoirierTarantola4th, v::Real)
     @unpack v0, b0, bp0, bpp0, e0 = eos
 
     x = (v / v0)^(1 / 3)
@@ -376,14 +376,14 @@ function apply(::Type{EnergyForm}, eos::PoirierTarantola4th, v::Real)
     h = b0 * bpp0 + bp0^2
     return e0 + b0 / 24v0 * xi^2 * ((h + 3bp0 + 3) * xi^2 + 4(bp0 + 2) * xi + 12)
 end
-function apply(::Type{EnergyForm}, eos::Vinet, v::Real)
+function apply(::EnergyForm, eos::Vinet, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = 3 / 2 * (bp0 - 1)
     return e0 + 9b0 * v0 / xi^2 * (1 + (xi * (1 - x) - 1) * exp(xi * (1 - x)))
 end
-function apply(::Type{EnergyForm}, eos::AntonSchmidt, v::Real)
+function apply(::EnergyForm, eos::AntonSchmidt, v::Real)
     @unpack v0, β, n, e∞ = eos
 
     x = v / v0
@@ -397,7 +397,7 @@ end
 #                              Pressure evaluation                             #
 # ============================================================================ #
 """
-    apply(PressureForm, eos::EquationOfState)
+    apply(PressureForm(), eos::EquationOfState)
 
 Return a function that can take a volume as a parameter, suitable for batch-applying.
 
@@ -405,7 +405,7 @@ Return a function that can take a volume as a parameter, suitable for batch-appl
 ```jldoctest
 julia> using EquationsOfState, EquationsOfState.Collections
 
-julia> f = apply(PressureForm, Vinet(1, 2, 3));
+julia> f = apply(PressureForm(), Vinet(1, 2, 3));
 
 julia> map(f, 1:1:10)
 10-element Array{Float64,1}:
@@ -421,45 +421,45 @@ julia> map(f, 1:1:10)
  -0.04674768462396211
 ```
 """
-apply(::Type{PressureForm}, eos::EquationOfState) = v -> apply(PressureForm, eos, v)
-function apply(::Type{PressureForm}, eos::Murnaghan, v::Real)
+apply(::PressureForm, eos::EquationOfState) = v -> apply(PressureForm(), eos, v)
+function apply(::PressureForm, eos::Murnaghan, v::Real)
     @unpack v0, b0, bp0 = eos
 
     return b0 / bp0 * ((v0 / v)^bp0 - 1)
 end
-function apply(::Type{PressureForm}, eos::BirchMurnaghan2nd, v::Real)
+function apply(::PressureForm, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return 3b0 * f * (1 + 2f)^(5 / 2)
 end
-function apply(::Type{PressureForm}, eos::BirchMurnaghan3rd, v::Real)
+function apply(::PressureForm, eos::BirchMurnaghan3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     eta = (v0 / v)^(1 / 3)
     return 3 / 2 * b0 * (eta^7 - eta^5) * (1 + 3 / 4 * (bp0 - 4) * (eta^2 - 1))
 end
-function apply(::Type{PressureForm}, eos::BirchMurnaghan4th, v::Real)
+function apply(::PressureForm, eos::BirchMurnaghan4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     h = b0 * bpp0 + bp0^2
     return b0 / 2 * (2f + 1)^(5 / 2) * ((9h - 63bp0 + 143) * f^2 + 9(bp0 - 4) * f + 6)
 end
-function apply(::Type{PressureForm}, eos::PoirierTarantola2nd, v::Real)
+function apply(::PressureForm, eos::PoirierTarantola2nd, v::Real)
     @unpack v0, b0 = eos
 
     x = (v / v0)^(1 / 3)
     return -b0 / x * log(x)
 end
-function apply(::Type{PressureForm}, eos::PoirierTarantola3rd, v::Real)
+function apply(::PressureForm, eos::PoirierTarantola3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = v / v0
     xi = log(x)
     return -b0 * xi / 2x * ((bp0 - 2) * xi - 2)
 end
-function apply(::Type{PressureForm}, eos::PoirierTarantola4th, v::Real)
+function apply(::PressureForm, eos::PoirierTarantola4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     x = (v / v0)^(1 / 3)
@@ -467,20 +467,20 @@ function apply(::Type{PressureForm}, eos::PoirierTarantola4th, v::Real)
     h = b0 * bpp0 + bp0^2
     return -b0 * xi / 6 / x * ((h + 3bp0 + 3) * xi^2 + 3(bp0 + 6) * xi + 6)
 end
-function apply(::Type{PressureForm}, eos::Vinet, v::Real)
+function apply(::PressureForm, eos::Vinet, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = 3 / 2 * (bp0 - 1)
     return 3b0 / x^2 * (1 - x) * exp(xi * (1 - x))
 end
-function apply(::Type{PressureForm}, eos::AntonSchmidt, v::Real)
+function apply(::PressureForm, eos::AntonSchmidt, v::Real)
     @unpack v0, β, n = eos
 
     x = v / v0
     return -β * x^n * log(x)
 end
-function apply(::Type{PressureForm}, eos::BreenanStacey, v::Real)
+function apply(::PressureForm, eos::BreenanStacey, v::Real)
     @unpack v0, b0, γ0 = eos
 
     x = v0 / v
@@ -493,7 +493,7 @@ end
 #                            Bulk modulus evaluation                           #
 # ============================================================================ #
 """
-    apply(BulkModulusForm, eos::EquationOfState)
+    apply(BulkModulusForm(), eos::EquationOfState)
 
 Return a function that can take a volume as a parameter, suitable for batch-applying.
 
@@ -501,7 +501,7 @@ Return a function that can take a volume as a parameter, suitable for batch-appl
 ```jldoctest
 julia> using EquationsOfState, EquationsOfState.Collections
 
-julia> f = apply(BulkModulusForm, BirchMurnaghan3rd(1, 2, 3));
+julia> f = apply(BulkModulusForm(), BirchMurnaghan3rd(1, 2, 3));
 
 julia> map(f, 1:1:10)
 10-element Array{Float64,1}:
@@ -517,40 +517,40 @@ julia> map(f, 1:1:10)
  0.03808959181078831 
 ```
 """
-apply(::Type{BulkModulusForm}, eos::EquationOfState) = v -> apply(BulkModulusForm, eos, v)
-function apply(::Type{BulkModulusForm}, eos::BirchMurnaghan2nd, v::Real)
+apply(::BulkModulusForm, eos::EquationOfState) = v -> apply(BulkModulusForm(), eos, v)
+function apply(::BulkModulusForm, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return b0 * (7f + 1) * (2f + 1)^(5 / 2)
 end
-function apply(::Type{BulkModulusForm}, eos::BirchMurnaghan3rd, v::Real)
+function apply(::BulkModulusForm, eos::BirchMurnaghan3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return b0 / 2 * (2f + 1)^(5 / 2) * ((27f^2 + 6f) * (bp0 - 4) - 4f + 2)
 end
-function apply(::Type{BulkModulusForm}, eos::BirchMurnaghan4th, v::Real)
+function apply(::BulkModulusForm, eos::BirchMurnaghan4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     h = b0 * bpp0 + bp0^2
     return b0 / 6 * (2f + 1)^(5 / 2) * ((99h - 693bp0 + 1573) * f^3 + (27h - 108bp0 + 105) * f^2 + 6f * (3bp0 - 5) + 6)
 end
-function apply(::Type{BulkModulusForm}, eos::PoirierTarantola2nd, v::Real)
+function apply(::BulkModulusForm, eos::PoirierTarantola2nd, v::Real)
     @unpack v0, b0 = eos
 
     x = (v / v0)^(1 / 3)
     return b0 / x * (1 - log(x))
 end
-function apply(::Type{BulkModulusForm}, eos::PoirierTarantola3rd, v::Real)
+function apply(::BulkModulusForm, eos::PoirierTarantola3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = v / v0
     xi = log(x)
     return -b0 / 2x * (((bp0 - 2) * xi + 2 - 2bp0) * xi + 2)
 end
-function apply(::Type{BulkModulusForm}, eos::PoirierTarantola4th, v::Real)
+function apply(::BulkModulusForm, eos::PoirierTarantola4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     x = (v / v0)^(1 / 3)
@@ -558,14 +558,14 @@ function apply(::Type{BulkModulusForm}, eos::PoirierTarantola4th, v::Real)
     h = b0 * bpp0 + bp0^2
     return -b0 / (6x) * ((h + 3bp0 + 3) * xi^3 - 3xi^2 * (h + 2bp0 + 1) - 6xi * (bp0 + 1) - 6)
 end
-function apply(::Type{BulkModulusForm}, eos::Vinet, v::Real)
+function apply(::BulkModulusForm, eos::Vinet, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = 3 / 2 * (bp0 - 1)
     return -b0 / (2x^2) * (3x * (x - 1) * (bp0 - 1) + 2(x - 2)) * exp(-xi * (x - 1))
 end
-function apply(::Type{BulkModulusForm}, eos::AntonSchmidt, v::Real)
+function apply(::BulkModulusForm, eos::AntonSchmidt, v::Real)
     @unpack v0, β, n = eos
 
     x = v / v0

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -397,7 +397,7 @@ end
 #                              Pressure evaluation                             #
 # ============================================================================ #
 """
-    calculate(PressureRelation, eos::EquationOfState)
+    calculate(PressureForm, eos::EquationOfState)
 
 Return a function that can take a volume as a parameter, suitable for batch-applying.
 
@@ -405,7 +405,7 @@ Return a function that can take a volume as a parameter, suitable for batch-appl
 ```jldoctest
 julia> using EquationsOfState, EquationsOfState.Collections
 
-julia> f = calculate(PressureRelation, Vinet(1, 2, 3));
+julia> f = calculate(PressureForm, Vinet(1, 2, 3));
 
 julia> map(f, 1:1:10)
 10-element Array{Float64,1}:
@@ -421,45 +421,45 @@ julia> map(f, 1:1:10)
  -0.04674768462396211
 ```
 """
-calculate(::Type{PressureRelation}, eos::EquationOfState) = v -> calculate(PressureRelation, eos, v)
-function calculate(::Type{PressureRelation}, eos::Murnaghan, v::Real)
+calculate(::Type{PressureForm}, eos::EquationOfState) = v -> calculate(PressureForm, eos, v)
+function calculate(::Type{PressureForm}, eos::Murnaghan, v::Real)
     @unpack v0, b0, bp0 = eos
 
     return b0 / bp0 * ((v0 / v)^bp0 - 1)
 end
-function calculate(::Type{PressureRelation}, eos::BirchMurnaghan2nd, v::Real)
+function calculate(::Type{PressureForm}, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return 3b0 * f * (1 + 2f)^(5 / 2)
 end
-function calculate(::Type{PressureRelation}, eos::BirchMurnaghan3rd, v::Real)
+function calculate(::Type{PressureForm}, eos::BirchMurnaghan3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     eta = (v0 / v)^(1 / 3)
     return 3 / 2 * b0 * (eta^7 - eta^5) * (1 + 3 / 4 * (bp0 - 4) * (eta^2 - 1))
 end
-function calculate(::Type{PressureRelation}, eos::BirchMurnaghan4th, v::Real)
+function calculate(::Type{PressureForm}, eos::BirchMurnaghan4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     h = b0 * bpp0 + bp0^2
     return b0 / 2 * (2f + 1)^(5 / 2) * ((9h - 63bp0 + 143) * f^2 + 9(bp0 - 4) * f + 6)
 end
-function calculate(::Type{PressureRelation}, eos::PoirierTarantola2nd, v::Real)
+function calculate(::Type{PressureForm}, eos::PoirierTarantola2nd, v::Real)
     @unpack v0, b0 = eos
 
     x = (v / v0)^(1 / 3)
     return -b0 / x * log(x)
 end
-function calculate(::Type{PressureRelation}, eos::PoirierTarantola3rd, v::Real)
+function calculate(::Type{PressureForm}, eos::PoirierTarantola3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = v / v0
     xi = log(x)
     return -b0 * xi / 2x * ((bp0 - 2) * xi - 2)
 end
-function calculate(::Type{PressureRelation}, eos::PoirierTarantola4th, v::Real)
+function calculate(::Type{PressureForm}, eos::PoirierTarantola4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     x = (v / v0)^(1 / 3)
@@ -467,20 +467,20 @@ function calculate(::Type{PressureRelation}, eos::PoirierTarantola4th, v::Real)
     h = b0 * bpp0 + bp0^2
     return -b0 * xi / 6 / x * ((h + 3bp0 + 3) * xi^2 + 3(bp0 + 6) * xi + 6)
 end
-function calculate(::Type{PressureRelation}, eos::Vinet, v::Real)
+function calculate(::Type{PressureForm}, eos::Vinet, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = 3 / 2 * (bp0 - 1)
     return 3b0 / x^2 * (1 - x) * exp(xi * (1 - x))
 end
-function calculate(::Type{PressureRelation}, eos::AntonSchmidt, v::Real)
+function calculate(::Type{PressureForm}, eos::AntonSchmidt, v::Real)
     @unpack v0, β, n = eos
 
     x = v / v0
     return -β * x^n * log(x)
 end
-function calculate(::Type{PressureRelation}, eos::BreenanStacey, v::Real)
+function calculate(::Type{PressureForm}, eos::BreenanStacey, v::Real)
     @unpack v0, b0, γ0 = eos
 
     x = v0 / v

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -19,7 +19,7 @@ using EquationsOfState
 
 import StaticArrays: similar_type
 
-export calculate,
+export apply,
        EquationOfState,
        FiniteStrainEquationOfState,
        PolynomialEquationOfState,
@@ -284,7 +284,7 @@ BreenanStacey(v0, b0, γ0) = BreenanStacey(v0, b0, γ0, 0)
 #                               Energy evaluation                              #
 # ============================================================================ #
 """
-    calculate(EnergyForm, eos::EquationOfState)
+    apply(EnergyForm, eos::EquationOfState)
 
 Return a function that can take a volume as a parameter, suitable for batch-applying.
 
@@ -292,7 +292,7 @@ Return a function that can take a volume as a parameter, suitable for batch-appl
 ```jldoctest
 julia> using EquationsOfState, EquationsOfState.Collections
 
-julia> f = calculate(EnergyForm, Vinet(1, 2, 3));
+julia> f = apply(EnergyForm, Vinet(1, 2, 3));
 
 julia> map(f, 1:1:10)
 10-element Array{Float64,1}:
@@ -308,13 +308,13 @@ julia> map(f, 1:1:10)
  1.7203642945516917
 ```
 """
-calculate(::Type{EnergyForm}, eos::EquationOfState) = v -> calculate(EnergyForm, eos, v)
+apply(::Type{EnergyForm}, eos::EquationOfState) = v -> apply(EnergyForm, eos, v)
 """
-    calculate(EnergyForm, eos::Murnaghan, v::Real)
+    apply(EnergyForm, eos::Murnaghan, v::Real)
 
 Return the energy of a `Murnaghan` equation of state on volume `v`.
 """
-function calculate(::Type{EnergyForm}, eos::Murnaghan, v::Real)
+function apply(::Type{EnergyForm}, eos::Murnaghan, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = bp0 - 1
@@ -322,22 +322,22 @@ function calculate(::Type{EnergyForm}, eos::Murnaghan, v::Real)
     return e0 + b0 / bp0 * v * (y / x + 1) - v0 * b0 / x
 end
 """
-    calculate(EnergyForm, eos::BirchMurnaghan2nd, v::Real)
+    apply(EnergyForm, eos::BirchMurnaghan2nd, v::Real)
 
 Return the energy of a `BirchMurnaghan2nd` equation of state on volume `v`.
 """
-function calculate(::Type{EnergyForm}, eos::BirchMurnaghan2nd, v::Real)
+function apply(::Type{EnergyForm}, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0, e0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return e0 + 9 / 2 * b0 * v0 * f^2
 end
 """
-    calculate(EnergyForm, eos::BirchMurnaghan3rd, v::Real)
+    apply(EnergyForm, eos::BirchMurnaghan3rd, v::Real)
 
 Return the energy of a `BirchMurnaghan3rd` equation of state on volume `v`.
 """
-function calculate(::Type{EnergyForm}, eos::BirchMurnaghan3rd, v::Real)
+function apply(::Type{EnergyForm}, eos::BirchMurnaghan3rd, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     eta = (v0 / v)^(1 / 3)
@@ -345,30 +345,30 @@ function calculate(::Type{EnergyForm}, eos::BirchMurnaghan3rd, v::Real)
     return e0 + 9 / 16 * b0 * v0 * xi^2 * (6 + bp0 * xi - 4eta^2)
 end
 """
-    calculate(EnergyForm, eos::BirchMurnaghan4th, v::Real)
+    apply(EnergyForm, eos::BirchMurnaghan4th, v::Real)
 
 Return the energy of a `BirchMurnaghan4th` equation of state on volume `v`.
 """
-function calculate(::Type{EnergyForm}, eos::BirchMurnaghan4th, v::Real)
+function apply(::Type{EnergyForm}, eos::BirchMurnaghan4th, v::Real)
     @unpack v0, b0, bp0, bpp0, e0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     h = b0 * bpp0 + bp0^2
     return e0 + 3 / 8 * v0 * b0 * f^2 * ((9h - 63bp0 + 143) * f^2 + 12(bp0 - 4) * f + 12)
 end
-function calculate(::Type{EnergyForm}, eos::PoirierTarantola2nd, v::Real)
+function apply(::Type{EnergyForm}, eos::PoirierTarantola2nd, v::Real)
     @unpack v0, b0, e0 = eos
 
     return e0 + b0 / 2 * v0 * log(v / v0)^(2 / 3)
 end
-function calculate(::Type{EnergyForm}, eos::PoirierTarantola3rd, v::Real)
+function apply(::Type{EnergyForm}, eos::PoirierTarantola3rd, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = -3log(x)
     return e0 + b0 / 6 * v0 * xi^2 * ((bp0 - 2) * xi + 3)
 end
-function calculate(::Type{EnergyForm}, eos::PoirierTarantola4th, v::Real)
+function apply(::Type{EnergyForm}, eos::PoirierTarantola4th, v::Real)
     @unpack v0, b0, bp0, bpp0, e0 = eos
 
     x = (v / v0)^(1 / 3)
@@ -376,14 +376,14 @@ function calculate(::Type{EnergyForm}, eos::PoirierTarantola4th, v::Real)
     h = b0 * bpp0 + bp0^2
     return e0 + b0 / 24v0 * xi^2 * ((h + 3bp0 + 3) * xi^2 + 4(bp0 + 2) * xi + 12)
 end
-function calculate(::Type{EnergyForm}, eos::Vinet, v::Real)
+function apply(::Type{EnergyForm}, eos::Vinet, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = 3 / 2 * (bp0 - 1)
     return e0 + 9b0 * v0 / xi^2 * (1 + (xi * (1 - x) - 1) * exp(xi * (1 - x)))
 end
-function calculate(::Type{EnergyForm}, eos::AntonSchmidt, v::Real)
+function apply(::Type{EnergyForm}, eos::AntonSchmidt, v::Real)
     @unpack v0, β, n, e∞ = eos
 
     x = v / v0
@@ -397,7 +397,7 @@ end
 #                              Pressure evaluation                             #
 # ============================================================================ #
 """
-    calculate(PressureForm, eos::EquationOfState)
+    apply(PressureForm, eos::EquationOfState)
 
 Return a function that can take a volume as a parameter, suitable for batch-applying.
 
@@ -405,7 +405,7 @@ Return a function that can take a volume as a parameter, suitable for batch-appl
 ```jldoctest
 julia> using EquationsOfState, EquationsOfState.Collections
 
-julia> f = calculate(PressureForm, Vinet(1, 2, 3));
+julia> f = apply(PressureForm, Vinet(1, 2, 3));
 
 julia> map(f, 1:1:10)
 10-element Array{Float64,1}:
@@ -421,45 +421,45 @@ julia> map(f, 1:1:10)
  -0.04674768462396211
 ```
 """
-calculate(::Type{PressureForm}, eos::EquationOfState) = v -> calculate(PressureForm, eos, v)
-function calculate(::Type{PressureForm}, eos::Murnaghan, v::Real)
+apply(::Type{PressureForm}, eos::EquationOfState) = v -> apply(PressureForm, eos, v)
+function apply(::Type{PressureForm}, eos::Murnaghan, v::Real)
     @unpack v0, b0, bp0 = eos
 
     return b0 / bp0 * ((v0 / v)^bp0 - 1)
 end
-function calculate(::Type{PressureForm}, eos::BirchMurnaghan2nd, v::Real)
+function apply(::Type{PressureForm}, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return 3b0 * f * (1 + 2f)^(5 / 2)
 end
-function calculate(::Type{PressureForm}, eos::BirchMurnaghan3rd, v::Real)
+function apply(::Type{PressureForm}, eos::BirchMurnaghan3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     eta = (v0 / v)^(1 / 3)
     return 3 / 2 * b0 * (eta^7 - eta^5) * (1 + 3 / 4 * (bp0 - 4) * (eta^2 - 1))
 end
-function calculate(::Type{PressureForm}, eos::BirchMurnaghan4th, v::Real)
+function apply(::Type{PressureForm}, eos::BirchMurnaghan4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     h = b0 * bpp0 + bp0^2
     return b0 / 2 * (2f + 1)^(5 / 2) * ((9h - 63bp0 + 143) * f^2 + 9(bp0 - 4) * f + 6)
 end
-function calculate(::Type{PressureForm}, eos::PoirierTarantola2nd, v::Real)
+function apply(::Type{PressureForm}, eos::PoirierTarantola2nd, v::Real)
     @unpack v0, b0 = eos
 
     x = (v / v0)^(1 / 3)
     return -b0 / x * log(x)
 end
-function calculate(::Type{PressureForm}, eos::PoirierTarantola3rd, v::Real)
+function apply(::Type{PressureForm}, eos::PoirierTarantola3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = v / v0
     xi = log(x)
     return -b0 * xi / 2x * ((bp0 - 2) * xi - 2)
 end
-function calculate(::Type{PressureForm}, eos::PoirierTarantola4th, v::Real)
+function apply(::Type{PressureForm}, eos::PoirierTarantola4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     x = (v / v0)^(1 / 3)
@@ -467,20 +467,20 @@ function calculate(::Type{PressureForm}, eos::PoirierTarantola4th, v::Real)
     h = b0 * bpp0 + bp0^2
     return -b0 * xi / 6 / x * ((h + 3bp0 + 3) * xi^2 + 3(bp0 + 6) * xi + 6)
 end
-function calculate(::Type{PressureForm}, eos::Vinet, v::Real)
+function apply(::Type{PressureForm}, eos::Vinet, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = 3 / 2 * (bp0 - 1)
     return 3b0 / x^2 * (1 - x) * exp(xi * (1 - x))
 end
-function calculate(::Type{PressureForm}, eos::AntonSchmidt, v::Real)
+function apply(::Type{PressureForm}, eos::AntonSchmidt, v::Real)
     @unpack v0, β, n = eos
 
     x = v / v0
     return -β * x^n * log(x)
 end
-function calculate(::Type{PressureForm}, eos::BreenanStacey, v::Real)
+function apply(::Type{PressureForm}, eos::BreenanStacey, v::Real)
     @unpack v0, b0, γ0 = eos
 
     x = v0 / v
@@ -493,7 +493,7 @@ end
 #                            Bulk modulus evaluation                           #
 # ============================================================================ #
 """
-    calculate(BulkModulusForm, eos::EquationOfState)
+    apply(BulkModulusForm, eos::EquationOfState)
 
 Return a function that can take a volume as a parameter, suitable for batch-applying.
 
@@ -501,7 +501,7 @@ Return a function that can take a volume as a parameter, suitable for batch-appl
 ```jldoctest
 julia> using EquationsOfState, EquationsOfState.Collections
 
-julia> f = calculate(BulkModulusForm, BirchMurnaghan3rd(1, 2, 3));
+julia> f = apply(BulkModulusForm, BirchMurnaghan3rd(1, 2, 3));
 
 julia> map(f, 1:1:10)
 10-element Array{Float64,1}:
@@ -517,40 +517,40 @@ julia> map(f, 1:1:10)
  0.03808959181078831 
 ```
 """
-calculate(::Type{BulkModulusForm}, eos::EquationOfState) = v -> calculate(BulkModulusForm, eos, v)
-function calculate(::Type{BulkModulusForm}, eos::BirchMurnaghan2nd, v::Real)
+apply(::Type{BulkModulusForm}, eos::EquationOfState) = v -> apply(BulkModulusForm, eos, v)
+function apply(::Type{BulkModulusForm}, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return b0 * (7f + 1) * (2f + 1)^(5 / 2)
 end
-function calculate(::Type{BulkModulusForm}, eos::BirchMurnaghan3rd, v::Real)
+function apply(::Type{BulkModulusForm}, eos::BirchMurnaghan3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return b0 / 2 * (2f + 1)^(5 / 2) * ((27f^2 + 6f) * (bp0 - 4) - 4f + 2)
 end
-function calculate(::Type{BulkModulusForm}, eos::BirchMurnaghan4th, v::Real)
+function apply(::Type{BulkModulusForm}, eos::BirchMurnaghan4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     h = b0 * bpp0 + bp0^2
     return b0 / 6 * (2f + 1)^(5 / 2) * ((99h - 693bp0 + 1573) * f^3 + (27h - 108bp0 + 105) * f^2 + 6f * (3bp0 - 5) + 6)
 end
-function calculate(::Type{BulkModulusForm}, eos::PoirierTarantola2nd, v::Real)
+function apply(::Type{BulkModulusForm}, eos::PoirierTarantola2nd, v::Real)
     @unpack v0, b0 = eos
 
     x = (v / v0)^(1 / 3)
     return b0 / x * (1 - log(x))
 end
-function calculate(::Type{BulkModulusForm}, eos::PoirierTarantola3rd, v::Real)
+function apply(::Type{BulkModulusForm}, eos::PoirierTarantola3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = v / v0
     xi = log(x)
     return -b0 / 2x * (((bp0 - 2) * xi + 2 - 2bp0) * xi + 2)
 end
-function calculate(::Type{BulkModulusForm}, eos::PoirierTarantola4th, v::Real)
+function apply(::Type{BulkModulusForm}, eos::PoirierTarantola4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     x = (v / v0)^(1 / 3)
@@ -558,14 +558,14 @@ function calculate(::Type{BulkModulusForm}, eos::PoirierTarantola4th, v::Real)
     h = b0 * bpp0 + bp0^2
     return -b0 / (6x) * ((h + 3bp0 + 3) * xi^3 - 3xi^2 * (h + 2bp0 + 1) - 6xi * (bp0 + 1) - 6)
 end
-function calculate(::Type{BulkModulusForm}, eos::Vinet, v::Real)
+function apply(::Type{BulkModulusForm}, eos::Vinet, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = 3 / 2 * (bp0 - 1)
     return -b0 / (2x^2) * (3x * (x - 1) * (bp0 - 1) + 2(x - 2)) * exp(-xi * (x - 1))
 end
-function calculate(::Type{BulkModulusForm}, eos::AntonSchmidt, v::Real)
+function apply(::Type{BulkModulusForm}, eos::AntonSchmidt, v::Real)
     @unpack v0, β, n = eos
 
     x = v / v0

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -310,7 +310,7 @@ julia> map(f, 1:1:10)
 """
 apply(::EnergyForm, eos::EquationOfState) = v -> apply(EnergyForm(), eos, v)
 """
-    apply(EnergyForm, eos::Murnaghan, v::Real)
+    apply(EnergyForm(), eos::Murnaghan, v::Real)
 
 Return the energy of a `Murnaghan` equation of state on volume `v`.
 """
@@ -322,7 +322,7 @@ function apply(::EnergyForm, eos::Murnaghan, v::Real)
     return e0 + b0 / bp0 * v * (y / x + 1) - v0 * b0 / x
 end
 """
-    apply(EnergyForm, eos::BirchMurnaghan2nd, v::Real)
+    apply(EnergyForm(), eos::BirchMurnaghan2nd, v::Real)
 
 Return the energy of a `BirchMurnaghan2nd` equation of state on volume `v`.
 """
@@ -333,7 +333,7 @@ function apply(::EnergyForm, eos::BirchMurnaghan2nd, v::Real)
     return e0 + 9 / 2 * b0 * v0 * f^2
 end
 """
-    apply(EnergyForm, eos::BirchMurnaghan3rd, v::Real)
+    apply(EnergyForm(), eos::BirchMurnaghan3rd, v::Real)
 
 Return the energy of a `BirchMurnaghan3rd` equation of state on volume `v`.
 """
@@ -345,7 +345,7 @@ function apply(::EnergyForm, eos::BirchMurnaghan3rd, v::Real)
     return e0 + 9 / 16 * b0 * v0 * xi^2 * (6 + bp0 * xi - 4eta^2)
 end
 """
-    apply(EnergyForm, eos::BirchMurnaghan4th, v::Real)
+    apply(EnergyForm(), eos::BirchMurnaghan4th, v::Real)
 
 Return the energy of a `BirchMurnaghan4th` equation of state on volume `v`.
 """

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -284,7 +284,7 @@ BreenanStacey(v0, b0, γ0) = BreenanStacey(v0, b0, γ0, 0)
 #                               Energy evaluation                              #
 # ============================================================================ #
 """
-    calculate(EnergyRelation, eos::EquationOfState)
+    calculate(EnergyForm, eos::EquationOfState)
 
 Return a function that can take a volume as a parameter, suitable for batch-applying.
 
@@ -292,7 +292,7 @@ Return a function that can take a volume as a parameter, suitable for batch-appl
 ```jldoctest
 julia> using EquationsOfState, EquationsOfState.Collections
 
-julia> f = calculate(EnergyRelation, Vinet(1, 2, 3));
+julia> f = calculate(EnergyForm, Vinet(1, 2, 3));
 
 julia> map(f, 1:1:10)
 10-element Array{Float64,1}:
@@ -308,13 +308,13 @@ julia> map(f, 1:1:10)
  1.7203642945516917
 ```
 """
-calculate(::Type{EnergyRelation}, eos::EquationOfState) = v -> calculate(EnergyRelation, eos, v)
+calculate(::Type{EnergyForm}, eos::EquationOfState) = v -> calculate(EnergyForm, eos, v)
 """
-    calculate(EnergyRelation, eos::Murnaghan, v::Real)
+    calculate(EnergyForm, eos::Murnaghan, v::Real)
 
 Return the energy of a `Murnaghan` equation of state on volume `v`.
 """
-function calculate(::Type{EnergyRelation}, eos::Murnaghan, v::Real)
+function calculate(::Type{EnergyForm}, eos::Murnaghan, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = bp0 - 1
@@ -322,22 +322,22 @@ function calculate(::Type{EnergyRelation}, eos::Murnaghan, v::Real)
     return e0 + b0 / bp0 * v * (y / x + 1) - v0 * b0 / x
 end
 """
-    calculate(EnergyRelation, eos::BirchMurnaghan2nd, v::Real)
+    calculate(EnergyForm, eos::BirchMurnaghan2nd, v::Real)
 
 Return the energy of a `BirchMurnaghan2nd` equation of state on volume `v`.
 """
-function calculate(::Type{EnergyRelation}, eos::BirchMurnaghan2nd, v::Real)
+function calculate(::Type{EnergyForm}, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0, e0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return e0 + 9 / 2 * b0 * v0 * f^2
 end
 """
-    calculate(EnergyRelation, eos::BirchMurnaghan3rd, v::Real)
+    calculate(EnergyForm, eos::BirchMurnaghan3rd, v::Real)
 
 Return the energy of a `BirchMurnaghan3rd` equation of state on volume `v`.
 """
-function calculate(::Type{EnergyRelation}, eos::BirchMurnaghan3rd, v::Real)
+function calculate(::Type{EnergyForm}, eos::BirchMurnaghan3rd, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     eta = (v0 / v)^(1 / 3)
@@ -345,30 +345,30 @@ function calculate(::Type{EnergyRelation}, eos::BirchMurnaghan3rd, v::Real)
     return e0 + 9 / 16 * b0 * v0 * xi^2 * (6 + bp0 * xi - 4eta^2)
 end
 """
-    calculate(EnergyRelation, eos::BirchMurnaghan4th, v::Real)
+    calculate(EnergyForm, eos::BirchMurnaghan4th, v::Real)
 
 Return the energy of a `BirchMurnaghan4th` equation of state on volume `v`.
 """
-function calculate(::Type{EnergyRelation}, eos::BirchMurnaghan4th, v::Real)
+function calculate(::Type{EnergyForm}, eos::BirchMurnaghan4th, v::Real)
     @unpack v0, b0, bp0, bpp0, e0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     h = b0 * bpp0 + bp0^2
     return e0 + 3 / 8 * v0 * b0 * f^2 * ((9h - 63bp0 + 143) * f^2 + 12(bp0 - 4) * f + 12)
 end
-function calculate(::Type{EnergyRelation}, eos::PoirierTarantola2nd, v::Real)
+function calculate(::Type{EnergyForm}, eos::PoirierTarantola2nd, v::Real)
     @unpack v0, b0, e0 = eos
 
     return e0 + b0 / 2 * v0 * log(v / v0)^(2 / 3)
 end
-function calculate(::Type{EnergyRelation}, eos::PoirierTarantola3rd, v::Real)
+function calculate(::Type{EnergyForm}, eos::PoirierTarantola3rd, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = -3log(x)
     return e0 + b0 / 6 * v0 * xi^2 * ((bp0 - 2) * xi + 3)
 end
-function calculate(::Type{EnergyRelation}, eos::PoirierTarantola4th, v::Real)
+function calculate(::Type{EnergyForm}, eos::PoirierTarantola4th, v::Real)
     @unpack v0, b0, bp0, bpp0, e0 = eos
 
     x = (v / v0)^(1 / 3)
@@ -376,14 +376,14 @@ function calculate(::Type{EnergyRelation}, eos::PoirierTarantola4th, v::Real)
     h = b0 * bpp0 + bp0^2
     return e0 + b0 / 24v0 * xi^2 * ((h + 3bp0 + 3) * xi^2 + 4(bp0 + 2) * xi + 12)
 end
-function calculate(::Type{EnergyRelation}, eos::Vinet, v::Real)
+function calculate(::Type{EnergyForm}, eos::Vinet, v::Real)
     @unpack v0, b0, bp0, e0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = 3 / 2 * (bp0 - 1)
     return e0 + 9b0 * v0 / xi^2 * (1 + (xi * (1 - x) - 1) * exp(xi * (1 - x)))
 end
-function calculate(::Type{EnergyRelation}, eos::AntonSchmidt, v::Real)
+function calculate(::Type{EnergyForm}, eos::AntonSchmidt, v::Real)
     @unpack v0, β, n, e∞ = eos
 
     x = v / v0

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -493,7 +493,7 @@ end
 #                            Bulk modulus evaluation                           #
 # ============================================================================ #
 """
-    calculate(BulkModulusRelation, eos::EquationOfState)
+    calculate(BulkModulusForm, eos::EquationOfState)
 
 Return a function that can take a volume as a parameter, suitable for batch-applying.
 
@@ -501,7 +501,7 @@ Return a function that can take a volume as a parameter, suitable for batch-appl
 ```jldoctest
 julia> using EquationsOfState, EquationsOfState.Collections
 
-julia> f = calculate(BulkModulusRelation, BirchMurnaghan3rd(1, 2, 3));
+julia> f = calculate(BulkModulusForm, BirchMurnaghan3rd(1, 2, 3));
 
 julia> map(f, 1:1:10)
 10-element Array{Float64,1}:
@@ -517,40 +517,40 @@ julia> map(f, 1:1:10)
  0.03808959181078831 
 ```
 """
-calculate(::Type{BulkModulusRelation}, eos::EquationOfState) = v -> calculate(BulkModulusRelation, eos, v)
-function calculate(::Type{BulkModulusRelation}, eos::BirchMurnaghan2nd, v::Real)
+calculate(::Type{BulkModulusForm}, eos::EquationOfState) = v -> calculate(BulkModulusForm, eos, v)
+function calculate(::Type{BulkModulusForm}, eos::BirchMurnaghan2nd, v::Real)
     @unpack v0, b0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return b0 * (7f + 1) * (2f + 1)^(5 / 2)
 end
-function calculate(::Type{BulkModulusRelation}, eos::BirchMurnaghan3rd, v::Real)
+function calculate(::Type{BulkModulusForm}, eos::BirchMurnaghan3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     return b0 / 2 * (2f + 1)^(5 / 2) * ((27f^2 + 6f) * (bp0 - 4) - 4f + 2)
 end
-function calculate(::Type{BulkModulusRelation}, eos::BirchMurnaghan4th, v::Real)
+function calculate(::Type{BulkModulusForm}, eos::BirchMurnaghan4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     f = ((v0 / v)^(2 / 3) - 1) / 2
     h = b0 * bpp0 + bp0^2
     return b0 / 6 * (2f + 1)^(5 / 2) * ((99h - 693bp0 + 1573) * f^3 + (27h - 108bp0 + 105) * f^2 + 6f * (3bp0 - 5) + 6)
 end
-function calculate(::Type{BulkModulusRelation}, eos::PoirierTarantola2nd, v::Real)
+function calculate(::Type{BulkModulusForm}, eos::PoirierTarantola2nd, v::Real)
     @unpack v0, b0 = eos
 
     x = (v / v0)^(1 / 3)
     return b0 / x * (1 - log(x))
 end
-function calculate(::Type{BulkModulusRelation}, eos::PoirierTarantola3rd, v::Real)
+function calculate(::Type{BulkModulusForm}, eos::PoirierTarantola3rd, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = v / v0
     xi = log(x)
     return -b0 / 2x * (((bp0 - 2) * xi + 2 - 2bp0) * xi + 2)
 end
-function calculate(::Type{BulkModulusRelation}, eos::PoirierTarantola4th, v::Real)
+function calculate(::Type{BulkModulusForm}, eos::PoirierTarantola4th, v::Real)
     @unpack v0, b0, bp0, bpp0 = eos
 
     x = (v / v0)^(1 / 3)
@@ -558,14 +558,14 @@ function calculate(::Type{BulkModulusRelation}, eos::PoirierTarantola4th, v::Rea
     h = b0 * bpp0 + bp0^2
     return -b0 / (6x) * ((h + 3bp0 + 3) * xi^3 - 3xi^2 * (h + 2bp0 + 1) - 6xi * (bp0 + 1) - 6)
 end
-function calculate(::Type{BulkModulusRelation}, eos::Vinet, v::Real)
+function calculate(::Type{BulkModulusForm}, eos::Vinet, v::Real)
     @unpack v0, b0, bp0 = eos
 
     x = (v / v0)^(1 / 3)
     xi = 3 / 2 * (bp0 - 1)
     return -b0 / (2x^2) * (3x * (x - 1) * (bp0 - 1) + 2(x - 2)) * exp(-xi * (x - 1))
 end
-function calculate(::Type{BulkModulusRelation}, eos::AntonSchmidt, v::Real)
+function calculate(::Type{BulkModulusForm}, eos::AntonSchmidt, v::Real)
     @unpack v0, β, n = eos
 
     x = v / v0

--- a/src/EquationsOfState.jl
+++ b/src/EquationsOfState.jl
@@ -1,10 +1,10 @@
 module EquationsOfState
 
-export EquationOfStateForm, EnergyRelation, PressureRelation, BulkModulusRelation
+export EquationOfStateForm, EnergyForm, PressureRelation, BulkModulusRelation
 
 abstract type EquationOfStateForm end
 
-struct EnergyRelation <: EquationOfStateForm end
+struct EnergyForm <: EquationOfStateForm end
 struct PressureRelation <: EquationOfStateForm end
 struct BulkModulusRelation <: EquationOfStateForm end
 

--- a/src/EquationsOfState.jl
+++ b/src/EquationsOfState.jl
@@ -1,11 +1,11 @@
 module EquationsOfState
 
-export EquationOfStateForm, EnergyForm, PressureRelation, BulkModulusRelation
+export EquationOfStateForm, EnergyForm, PressureForm, BulkModulusRelation
 
 abstract type EquationOfStateForm end
 
 struct EnergyForm <: EquationOfStateForm end
-struct PressureRelation <: EquationOfStateForm end
+struct PressureForm <: EquationOfStateForm end
 struct BulkModulusRelation <: EquationOfStateForm end
 
 include("Collections.jl")

--- a/src/EquationsOfState.jl
+++ b/src/EquationsOfState.jl
@@ -1,12 +1,12 @@
 module EquationsOfState
 
-export EquationOfStateForm, EnergyForm, PressureForm, BulkModulusRelation
+export EquationOfStateForm, EnergyForm, PressureForm, BulkModulusForm
 
 abstract type EquationOfStateForm end
 
 struct EnergyForm <: EquationOfStateForm end
 struct PressureForm <: EquationOfStateForm end
-struct BulkModulusRelation <: EquationOfStateForm end
+struct BulkModulusForm <: EquationOfStateForm end
 
 include("Collections.jl")
 include("NonlinearFitting.jl")

--- a/src/EquationsOfState.jl
+++ b/src/EquationsOfState.jl
@@ -1,12 +1,12 @@
 module EquationsOfState
 
-export EquationOfStateRelation, EnergyRelation, PressureRelation, BulkModulusRelation
+export EquationOfStateForm, EnergyRelation, PressureRelation, BulkModulusRelation
 
-abstract type EquationOfStateRelation end
+abstract type EquationOfStateForm end
 
-struct EnergyRelation <: EquationOfStateRelation end
-struct PressureRelation <: EquationOfStateRelation end
-struct BulkModulusRelation <: EquationOfStateRelation end
+struct EnergyRelation <: EquationOfStateForm end
+struct PressureRelation <: EquationOfStateForm end
+struct BulkModulusRelation <: EquationOfStateForm end
 
 include("Collections.jl")
 include("NonlinearFitting.jl")

--- a/src/FindVolume.jl
+++ b/src/FindVolume.jl
@@ -18,8 +18,8 @@ using EquationsOfState.Collections
 
 export find_volume
 
-function find_volume(T::Type{<:EquationOfStateForm}, eos::EquationOfState, y::Real, interval, method)
-    f = v -> apply(T, eos, v) - y
+function find_volume(form::EquationOfStateForm, eos::EquationOfState, y::Real, interval, method)
+    f = v -> apply(form, eos, v) - y
     solutions = roots(f, interval, method)
     length(solutions) != 1 ? error("Multiple roots find!") : return first(solutions)
 end # function find_volume

--- a/src/FindVolume.jl
+++ b/src/FindVolume.jl
@@ -19,7 +19,7 @@ using EquationsOfState.Collections
 export find_volume
 
 function find_volume(T::Type{<:EquationOfStateForm}, eos::EquationOfState, y::Real, interval, method)
-    f = v -> calculate(T, eos, v) - y
+    f = v -> apply(T, eos, v) - y
     solutions = roots(f, interval, method)
     length(solutions) != 1 ? error("Multiple roots find!") : return first(solutions)
 end # function find_volume

--- a/src/FindVolume.jl
+++ b/src/FindVolume.jl
@@ -18,7 +18,7 @@ using EquationsOfState.Collections
 
 export find_volume
 
-function find_volume(T::Type{<:EquationOfStateRelation}, eos::EquationOfState, y::Real, interval, method)
+function find_volume(T::Type{<:EquationOfStateForm}, eos::EquationOfState, y::Real, interval, method)
     f = v -> calculate(T, eos, v) - y
     solutions = roots(f, interval, method)
     length(solutions) != 1 ? error("Multiple roots find!") : return first(solutions)

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -19,7 +19,7 @@ using EquationsOfState.Collections
 export lsqfit
 
 function lsqfit(
-    A::Type{<:EquationOfStateRelation},
+    A::Type{<:EquationOfStateForm},
     eos::E,
     xdata::Vector{T},
     ydata::Vector{T};
@@ -35,7 +35,7 @@ end  # function lsqfit
 Fit an equation of state using least-squares fitting method (with the Levenberg-Marquardt algorithm).
 
 # Arguments
-- `T::Type{<:EquationOfStateRelation}`: an `EquationOfStateRelation`. If it is `EnergyRelation`, fit ``E(V)``; if `PressureRelation`, fit ``P(V)``; if `BulkModulusRelation`, fit ``B(V)``.
+- `T::Type{<:EquationOfStateForm}`: an `EquationOfStateForm`. If it is `EnergyRelation`, fit ``E(V)``; if `PressureRelation`, fit ``P(V)``; if `BulkModulusRelation`, fit ``B(V)``.
 - `eos::EquationOfState`: a trial equation of state.
 - `xdata::AbstractVector`: a vector of volumes.
 - `ydata::AbstractVector`: a vector of energies, pressures, or bulk moduli.
@@ -43,7 +43,7 @@ Fit an equation of state using least-squares fitting method (with the Levenberg-
 - `kwargs`: the rest keyword arguments that will be sent to `LsqFit.curve_fit`. See its [documentation](https://github.com/JuliaNLSolvers/LsqFit.jl/blob/master/README.md).
 """
 function lsqfit(
-    A::Type{<:EquationOfStateRelation},
+    A::Type{<:EquationOfStateForm},
     eos::E,
     xdata::X,
     ydata::Y;

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -35,7 +35,7 @@ end  # function lsqfit
 Fit an equation of state using least-squares fitting method (with the Levenberg-Marquardt algorithm).
 
 # Arguments
-- `T::Type{<:EquationOfStateForm}`: an `EquationOfStateForm`. If it is `EnergyForm`, fit ``E(V)``; if `PressureRelation`, fit ``P(V)``; if `BulkModulusRelation`, fit ``B(V)``.
+- `T::Type{<:EquationOfStateForm}`: an `EquationOfStateForm`. If it is `EnergyForm`, fit ``E(V)``; if `PressureForm`, fit ``P(V)``; if `BulkModulusRelation`, fit ``B(V)``.
 - `eos::EquationOfState`: a trial equation of state.
 - `xdata::AbstractVector`: a vector of volumes.
 - `ydata::AbstractVector`: a vector of energies, pressures, or bulk moduli.

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -19,23 +19,23 @@ using EquationsOfState.Collections
 export lsqfit
 
 function lsqfit(
-    A::Type{<:EquationOfStateForm},
+    form::EquationOfStateForm,
     eos::E,
     xdata::Vector{T},
     ydata::Vector{T};
     debug::Bool = false, kwargs...
 ) where {T<:AbstractFloat,E<:EquationOfState{T}}
-    model(x, p) = map(apply(A, E(p)), x)
+    model(x, p) = map(apply(form, E(p)), x)
     fitted = curve_fit(model, xdata, ydata, collect(eos); kwargs...)
     debug ? fitted : E(fitted.param)
 end  # function lsqfit
 """
-    lsqfit(T, eos, xdata, ydata; debug = false, kwargs...)
+    lsqfit(form, eos, xdata, ydata; debug = false, kwargs...)
 
 Fit an equation of state using least-squares fitting method (with the Levenberg-Marquardt algorithm).
 
 # Arguments
-- `T::Type{<:EquationOfStateForm}`: an `EquationOfStateForm`. If it is `EnergyForm`, fit ``E(V)``; if `PressureForm`, fit ``P(V)``; if `BulkModulusForm`, fit ``B(V)``.
+- `form::EquationOfStateForm`: an `EquationOfStateForm` instance. If `EnergyForm`, fit ``E(V)``; if `PressureForm`, fit ``P(V)``; if `BulkModulusForm`, fit ``B(V)``.
 - `eos::EquationOfState`: a trial equation of state.
 - `xdata::AbstractVector`: a vector of volumes.
 - `ydata::AbstractVector`: a vector of energies, pressures, or bulk moduli.
@@ -43,14 +43,14 @@ Fit an equation of state using least-squares fitting method (with the Levenberg-
 - `kwargs`: the rest keyword arguments that will be sent to `LsqFit.curve_fit`. See its [documentation](https://github.com/JuliaNLSolvers/LsqFit.jl/blob/master/README.md).
 """
 function lsqfit(
-    A::Type{<:EquationOfStateForm},
+    form::EquationOfStateForm,
     eos::E,
     xdata::X,
     ydata::Y;
     kwargs...
 ) where {E<:EquationOfState,X<:AbstractVector,Y<:AbstractVector}
     T = promote_type(eltype(eos), eltype(xdata), eltype(ydata), Float64)
-    lsqfit(A, convert(similar_type(E, T), eos), convert(Vector{T}, xdata), convert(Vector{T}, ydata); kwargs...)
+    lsqfit(form, convert(similar_type(E, T), eos), convert(Vector{T}, xdata), convert(Vector{T}, ydata); kwargs...)
 end  # function lsqfit
 
 end

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -25,7 +25,7 @@ function lsqfit(
     ydata::Vector{T};
     debug::Bool = false, kwargs...
 ) where {T<:AbstractFloat,E<:EquationOfState{T}}
-    model(x, p) = map(calculate(A, E(p)), x)
+    model(x, p) = map(apply(A, E(p)), x)
     fitted = curve_fit(model, xdata, ydata, collect(eos); kwargs...)
     debug ? fitted : E(fitted.param)
 end  # function lsqfit

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -35,7 +35,7 @@ end  # function lsqfit
 Fit an equation of state using least-squares fitting method (with the Levenberg-Marquardt algorithm).
 
 # Arguments
-- `T::Type{<:EquationOfStateForm}`: an `EquationOfStateForm`. If it is `EnergyRelation`, fit ``E(V)``; if `PressureRelation`, fit ``P(V)``; if `BulkModulusRelation`, fit ``B(V)``.
+- `T::Type{<:EquationOfStateForm}`: an `EquationOfStateForm`. If it is `EnergyForm`, fit ``E(V)``; if `PressureRelation`, fit ``P(V)``; if `BulkModulusRelation`, fit ``B(V)``.
 - `eos::EquationOfState`: a trial equation of state.
 - `xdata::AbstractVector`: a vector of volumes.
 - `ydata::AbstractVector`: a vector of energies, pressures, or bulk moduli.

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -35,7 +35,7 @@ end  # function lsqfit
 Fit an equation of state using least-squares fitting method (with the Levenberg-Marquardt algorithm).
 
 # Arguments
-- `T::Type{<:EquationOfStateForm}`: an `EquationOfStateForm`. If it is `EnergyForm`, fit ``E(V)``; if `PressureForm`, fit ``P(V)``; if `BulkModulusRelation`, fit ``B(V)``.
+- `T::Type{<:EquationOfStateForm}`: an `EquationOfStateForm`. If it is `EnergyForm`, fit ``E(V)``; if `PressureForm`, fit ``P(V)``; if `BulkModulusForm`, fit ``B(V)``.
 - `eos::EquationOfState`: a trial equation of state.
 - `xdata::AbstractVector`: a vector of volumes.
 - `ydata::AbstractVector`: a vector of energies, pressures, or bulk moduli.

--- a/test/NonlinearFitting.jl
+++ b/test/NonlinearFitting.jl
@@ -7,22 +7,22 @@ using EquationsOfState.NonlinearFitting
 @testset "Test fitting energy with different element types" begin
     result = BirchMurnaghan3rd(0.0057009512119028044, 103.58772269057364, -144.45152457521132, -40.31992619868024)
     @test isapprox(
-        lsqfit(EnergyForm, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        lsqfit(EnergyForm(), BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(EnergyForm, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
+        lsqfit(EnergyForm(), BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(EnergyForm, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]),
+        lsqfit(EnergyForm(), BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]),
         result;
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(EnergyForm, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        lsqfit(EnergyForm(), BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-5
     )
@@ -140,19 +140,19 @@ end
         -9.73155247952
     ]
     @test isapprox(
-        lsqfit(EnergyForm, BirchMurnaghan3rd(40, 0.5, 4, 0), volumes, energies),
+        lsqfit(EnergyForm(), BirchMurnaghan3rd(40, 0.5, 4, 0), volumes, energies),
         BirchMurnaghan3rd(40.98926572528106, 0.5369258245417454, 4.178644235500821, -10.842803908240892)
     )
     @test isapprox(
-        lsqfit(EnergyForm, Murnaghan(41, 0.5, 4, 0), volumes, energies),
+        lsqfit(EnergyForm(), Murnaghan(41, 0.5, 4, 0), volumes, energies),
         Murnaghan(41.13757930387086, 0.5144967693786603, 3.9123862262572264, -10.836794514626673)
     )
     @test isapprox(
-        lsqfit(EnergyForm, PoirierTarantola3rd(41, 0.5, 4, 0), volumes, energies),
+        lsqfit(EnergyForm(), PoirierTarantola3rd(41, 0.5, 4, 0), volumes, energies),
         PoirierTarantola3rd(40.86770643373908, 0.5667729960804602, 4.331688936974368, -10.851486685041658)
     )
     @test isapprox(
-        lsqfit(EnergyForm, Vinet(41, 0.5, 4, 0), volumes, energies),
+        lsqfit(EnergyForm(), Vinet(41, 0.5, 4, 0), volumes, energies),
         Vinet(40.916875663779784, 0.5493839425156859, 4.3051929654936885, -10.846160810560756)
     )
     # 'deltafactor': {'b0': 0.5369258245611414,
@@ -239,7 +239,7 @@ end
         -1.594410995
     ]
 
-    fitted_eos = lsqfit(EnergyForm, Vinet(23, 0.5, 4, -2), mp153_volumes, mp153_energies)
+    fitted_eos = lsqfit(EnergyForm(), Vinet(23, 0.5, 4, -2), mp153_volumes, mp153_energies)
     @test isapprox(fitted_eos, Vinet(22.95764559358769, 0.2257091141420788, 4.060543387224629, -1.5944292606251582))
     @test isapprox(map(apply(EnergyForm, fitted_eos), mp153_volumes), mp153_known_energies_vinet; atol = 1e-5)
 end
@@ -317,7 +317,7 @@ end
         -5.118654229
     ]
 
-    fitted_eos = lsqfit(EnergyForm, Vinet(20, 0.5, 4, -5), mp149_volumes, mp149_energies)
+    fitted_eos = lsqfit(EnergyForm(), Vinet(20, 0.5, 4, -5), mp149_volumes, mp149_energies)
     @test isapprox(fitted_eos, Vinet(20.446696754873944, 0.5516638521306302, 4.324373909783161, -5.424963389876503))
     @test isapprox(map(apply(EnergyForm, fitted_eos), mp149_volumes), mp149_known_energies_vinet; atol = 1e-5)
 end
@@ -395,7 +395,7 @@ end
         -7.897414664
     ]
 
-    fitted_eos = lsqfit(EnergyForm, Vinet(17, 0.5, 4, -7), mp72_volumes, mp72_energies)
+    fitted_eos = lsqfit(EnergyForm(), Vinet(17, 0.5, 4, -7), mp72_volumes, mp72_energies)
     @test isapprox(fitted_eos, Vinet(17.13223026131245, 0.7029766224730147, 3.6388077563621812, -7.897414959124461))
     @test isapprox(map(apply(EnergyForm, fitted_eos), mp72_volumes), mp72_known_energies_vinet; atol = 1e-5)
 end
@@ -466,26 +466,26 @@ end
     ]
     volumes = data[:, 1]  # unit: bohr^3
     energies = data[:, 2]  # unit: Rydberg
-    @test lsqfit(EnergyForm, BirchMurnaghan3rd(224, 0.0006, 4, -323), volumes, energies) ≈ BirchMurnaghan3rd(
+    @test lsqfit(EnergyForm(), BirchMurnaghan3rd(224, 0.0006, 4, -323), volumes, energies) ≈ BirchMurnaghan3rd(
         224.444565,
         0.00062506191050572675,
         3.740369,
         -323.417714
     )
     @test isapprox(
-        lsqfit(EnergyForm, BirchMurnaghan4th(224, 0.0006, 4, -5460, -323), volumes, energies),
+        lsqfit(EnergyForm(), BirchMurnaghan4th(224, 0.0006, 4, -5460, -323), volumes, energies),
         BirchMurnaghan4th(224.457562, 0.00062293812247621543, 3.730992, -5322.69673452213, -323.417712);
         atol = 1e-3
     )
     @test isapprox(
-        lsqfit(EnergyForm, Murnaghan(224, 0.006, 4, -323), volumes, energies),
+        lsqfit(EnergyForm(), Murnaghan(224, 0.006, 4, -323), volumes, energies),
         Murnaghan(224.501825, 0.00060479524074699499, 3.723835, -323.417686);
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(EnergyForm, PoirierTarantola3rd(100, 0.0006, 3.7, -323), volumes, energies),
+        lsqfit(EnergyForm(), PoirierTarantola3rd(100, 0.0006, 3.7, -323), volumes, energies),
         PoirierTarantola3rd(224.509208, 0.000635892264159838, 3.690448, -323.41773);
         atol = 1e-5
     )
-    # @test lsqfit(EnergyForm, PoirierTarantola4th(220, 0.0006, 3.7, -5500, -323), volumes, energies; lower = Float64[220, 0, 3, -6000, -400], upper = Float64[300, 0.01, 5, -5000, -300]) ≈ PoirierTarantola4th(224.430182, 0.0006232241765069493, 3.758360, -5493.859729817176, -323.417712)
+    # @test lsqfit(EnergyForm(), PoirierTarantola4th(220, 0.0006, 3.7, -5500, -323), volumes, energies; lower = Float64[220, 0, 3, -6000, -400], upper = Float64[300, 0.01, 5, -5000, -300]) ≈ PoirierTarantola4th(224.430182, 0.0006232241765069493, 3.758360, -5493.859729817176, -323.417712)
 end

--- a/test/NonlinearFitting.jl
+++ b/test/NonlinearFitting.jl
@@ -241,7 +241,7 @@ end
 
     fitted_eos = lsqfit(EnergyForm, Vinet(23, 0.5, 4, -2), mp153_volumes, mp153_energies)
     @test isapprox(fitted_eos, Vinet(22.95764559358769, 0.2257091141420788, 4.060543387224629, -1.5944292606251582))
-    @test isapprox(map(calculate(EnergyForm, fitted_eos), mp153_volumes), mp153_known_energies_vinet; atol = 1e-5)
+    @test isapprox(map(apply(EnergyForm, fitted_eos), mp153_volumes), mp153_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "Test Si dataset" begin
@@ -319,7 +319,7 @@ end
 
     fitted_eos = lsqfit(EnergyForm, Vinet(20, 0.5, 4, -5), mp149_volumes, mp149_energies)
     @test isapprox(fitted_eos, Vinet(20.446696754873944, 0.5516638521306302, 4.324373909783161, -5.424963389876503))
-    @test isapprox(map(calculate(EnergyForm, fitted_eos), mp149_volumes), mp149_known_energies_vinet; atol = 1e-5)
+    @test isapprox(map(apply(EnergyForm, fitted_eos), mp149_volumes), mp149_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "Test Ti dataset" begin
@@ -397,7 +397,7 @@ end
 
     fitted_eos = lsqfit(EnergyForm, Vinet(17, 0.5, 4, -7), mp72_volumes, mp72_energies)
     @test isapprox(fitted_eos, Vinet(17.13223026131245, 0.7029766224730147, 3.6388077563621812, -7.897414959124461))
-    @test isapprox(map(calculate(EnergyForm, fitted_eos), mp72_volumes), mp72_known_energies_vinet; atol = 1e-5)
+    @test isapprox(map(apply(EnergyForm, fitted_eos), mp72_volumes), mp72_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "`Test w2k-lda-na.dat` from `Gibbs2`" begin

--- a/test/NonlinearFitting.jl
+++ b/test/NonlinearFitting.jl
@@ -31,22 +31,22 @@ end
 @testset "Test fitting pressure with different element types" begin
     result = BirchMurnaghan3rd(1.1024687826597717, 29.30861698140365, 12.689089871112746, 0.0)
     @test isapprox(
-        lsqfit(PressureForm, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        lsqfit(PressureForm(), BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-6
     )
     @test isapprox(
-        lsqfit(PressureForm, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
+        lsqfit(PressureForm(), BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-6
     )
     @test isapprox(
-        lsqfit(PressureForm, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]),
+        lsqfit(PressureForm(), BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]),
         result;
         atol = 1e-6
     )
     @test isapprox(
-        lsqfit(PressureForm, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        lsqfit(PressureForm(), BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-6
     )
@@ -241,7 +241,7 @@ end
 
     fitted_eos = lsqfit(EnergyForm(), Vinet(23, 0.5, 4, -2), mp153_volumes, mp153_energies)
     @test isapprox(fitted_eos, Vinet(22.95764559358769, 0.2257091141420788, 4.060543387224629, -1.5944292606251582))
-    @test isapprox(map(apply(EnergyForm, fitted_eos), mp153_volumes), mp153_known_energies_vinet; atol = 1e-5)
+    @test isapprox(map(apply(EnergyForm(), fitted_eos), mp153_volumes), mp153_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "Test Si dataset" begin
@@ -319,7 +319,7 @@ end
 
     fitted_eos = lsqfit(EnergyForm(), Vinet(20, 0.5, 4, -5), mp149_volumes, mp149_energies)
     @test isapprox(fitted_eos, Vinet(20.446696754873944, 0.5516638521306302, 4.324373909783161, -5.424963389876503))
-    @test isapprox(map(apply(EnergyForm, fitted_eos), mp149_volumes), mp149_known_energies_vinet; atol = 1e-5)
+    @test isapprox(map(apply(EnergyForm(), fitted_eos), mp149_volumes), mp149_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "Test Ti dataset" begin
@@ -397,7 +397,7 @@ end
 
     fitted_eos = lsqfit(EnergyForm(), Vinet(17, 0.5, 4, -7), mp72_volumes, mp72_energies)
     @test isapprox(fitted_eos, Vinet(17.13223026131245, 0.7029766224730147, 3.6388077563621812, -7.897414959124461))
-    @test isapprox(map(apply(EnergyForm, fitted_eos), mp72_volumes), mp72_known_energies_vinet; atol = 1e-5)
+    @test isapprox(map(apply(EnergyForm(), fitted_eos), mp72_volumes), mp72_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "`Test w2k-lda-na.dat` from `Gibbs2`" begin

--- a/test/NonlinearFitting.jl
+++ b/test/NonlinearFitting.jl
@@ -55,22 +55,22 @@ end
 @testset "Test fitting bulk modulus with different element types" begin
     result = BirchMurnaghan3rd(7.218928431312577, 5.007900469653902, 4.06037725509478, 0.0)
     @test isapprox(
-        lsqfit(BulkModulusForm, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        lsqfit(BulkModulusForm(), BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(BulkModulusForm, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
+        lsqfit(BulkModulusForm(), BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(BulkModulusForm, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]),
+        lsqfit(BulkModulusForm(), BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]),
         result;
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(BulkModulusForm, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        lsqfit(BulkModulusForm(), BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-5
     )

--- a/test/NonlinearFitting.jl
+++ b/test/NonlinearFitting.jl
@@ -31,22 +31,22 @@ end
 @testset "Test fitting pressure with different element types" begin
     result = BirchMurnaghan3rd(1.1024687826597717, 29.30861698140365, 12.689089871112746, 0.0)
     @test isapprox(
-        lsqfit(PressureRelation, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        lsqfit(PressureForm, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-6
     )
     @test isapprox(
-        lsqfit(PressureRelation, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
+        lsqfit(PressureForm, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-6
     )
     @test isapprox(
-        lsqfit(PressureRelation, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]),
+        lsqfit(PressureForm, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]),
         result;
         atol = 1e-6
     )
     @test isapprox(
-        lsqfit(PressureRelation, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        lsqfit(PressureForm, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-6
     )

--- a/test/NonlinearFitting.jl
+++ b/test/NonlinearFitting.jl
@@ -7,22 +7,22 @@ using EquationsOfState.NonlinearFitting
 @testset "Test fitting energy with different element types" begin
     result = BirchMurnaghan3rd(0.0057009512119028044, 103.58772269057364, -144.45152457521132, -40.31992619868024)
     @test isapprox(
-        lsqfit(EnergyRelation, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        lsqfit(EnergyForm, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(EnergyRelation, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
+        lsqfit(EnergyForm, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(EnergyRelation, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]),
+        lsqfit(EnergyForm, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]),
         result;
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(EnergyRelation, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        lsqfit(EnergyForm, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-5
     )
@@ -140,19 +140,19 @@ end
         -9.73155247952
     ]
     @test isapprox(
-        lsqfit(EnergyRelation, BirchMurnaghan3rd(40, 0.5, 4, 0), volumes, energies),
+        lsqfit(EnergyForm, BirchMurnaghan3rd(40, 0.5, 4, 0), volumes, energies),
         BirchMurnaghan3rd(40.98926572528106, 0.5369258245417454, 4.178644235500821, -10.842803908240892)
     )
     @test isapprox(
-        lsqfit(EnergyRelation, Murnaghan(41, 0.5, 4, 0), volumes, energies),
+        lsqfit(EnergyForm, Murnaghan(41, 0.5, 4, 0), volumes, energies),
         Murnaghan(41.13757930387086, 0.5144967693786603, 3.9123862262572264, -10.836794514626673)
     )
     @test isapprox(
-        lsqfit(EnergyRelation, PoirierTarantola3rd(41, 0.5, 4, 0), volumes, energies),
+        lsqfit(EnergyForm, PoirierTarantola3rd(41, 0.5, 4, 0), volumes, energies),
         PoirierTarantola3rd(40.86770643373908, 0.5667729960804602, 4.331688936974368, -10.851486685041658)
     )
     @test isapprox(
-        lsqfit(EnergyRelation, Vinet(41, 0.5, 4, 0), volumes, energies),
+        lsqfit(EnergyForm, Vinet(41, 0.5, 4, 0), volumes, energies),
         Vinet(40.916875663779784, 0.5493839425156859, 4.3051929654936885, -10.846160810560756)
     )
     # 'deltafactor': {'b0': 0.5369258245611414,
@@ -239,9 +239,9 @@ end
         -1.594410995
     ]
 
-    fitted_eos = lsqfit(EnergyRelation, Vinet(23, 0.5, 4, -2), mp153_volumes, mp153_energies)
+    fitted_eos = lsqfit(EnergyForm, Vinet(23, 0.5, 4, -2), mp153_volumes, mp153_energies)
     @test isapprox(fitted_eos, Vinet(22.95764559358769, 0.2257091141420788, 4.060543387224629, -1.5944292606251582))
-    @test isapprox(map(calculate(EnergyRelation, fitted_eos), mp153_volumes), mp153_known_energies_vinet; atol = 1e-5)
+    @test isapprox(map(calculate(EnergyForm, fitted_eos), mp153_volumes), mp153_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "Test Si dataset" begin
@@ -317,9 +317,9 @@ end
         -5.118654229
     ]
 
-    fitted_eos = lsqfit(EnergyRelation, Vinet(20, 0.5, 4, -5), mp149_volumes, mp149_energies)
+    fitted_eos = lsqfit(EnergyForm, Vinet(20, 0.5, 4, -5), mp149_volumes, mp149_energies)
     @test isapprox(fitted_eos, Vinet(20.446696754873944, 0.5516638521306302, 4.324373909783161, -5.424963389876503))
-    @test isapprox(map(calculate(EnergyRelation, fitted_eos), mp149_volumes), mp149_known_energies_vinet; atol = 1e-5)
+    @test isapprox(map(calculate(EnergyForm, fitted_eos), mp149_volumes), mp149_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "Test Ti dataset" begin
@@ -395,9 +395,9 @@ end
         -7.897414664
     ]
 
-    fitted_eos = lsqfit(EnergyRelation, Vinet(17, 0.5, 4, -7), mp72_volumes, mp72_energies)
+    fitted_eos = lsqfit(EnergyForm, Vinet(17, 0.5, 4, -7), mp72_volumes, mp72_energies)
     @test isapprox(fitted_eos, Vinet(17.13223026131245, 0.7029766224730147, 3.6388077563621812, -7.897414959124461))
-    @test isapprox(map(calculate(EnergyRelation, fitted_eos), mp72_volumes), mp72_known_energies_vinet; atol = 1e-5)
+    @test isapprox(map(calculate(EnergyForm, fitted_eos), mp72_volumes), mp72_known_energies_vinet; atol = 1e-5)
 end
 
 @testset "`Test w2k-lda-na.dat` from `Gibbs2`" begin
@@ -466,26 +466,26 @@ end
     ]
     volumes = data[:, 1]  # unit: bohr^3
     energies = data[:, 2]  # unit: Rydberg
-    @test lsqfit(EnergyRelation, BirchMurnaghan3rd(224, 0.0006, 4, -323), volumes, energies) ≈ BirchMurnaghan3rd(
+    @test lsqfit(EnergyForm, BirchMurnaghan3rd(224, 0.0006, 4, -323), volumes, energies) ≈ BirchMurnaghan3rd(
         224.444565,
         0.00062506191050572675,
         3.740369,
         -323.417714
     )
     @test isapprox(
-        lsqfit(EnergyRelation, BirchMurnaghan4th(224, 0.0006, 4, -5460, -323), volumes, energies),
+        lsqfit(EnergyForm, BirchMurnaghan4th(224, 0.0006, 4, -5460, -323), volumes, energies),
         BirchMurnaghan4th(224.457562, 0.00062293812247621543, 3.730992, -5322.69673452213, -323.417712);
         atol = 1e-3
     )
     @test isapprox(
-        lsqfit(EnergyRelation, Murnaghan(224, 0.006, 4, -323), volumes, energies),
+        lsqfit(EnergyForm, Murnaghan(224, 0.006, 4, -323), volumes, energies),
         Murnaghan(224.501825, 0.00060479524074699499, 3.723835, -323.417686);
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(EnergyRelation, PoirierTarantola3rd(100, 0.0006, 3.7, -323), volumes, energies),
+        lsqfit(EnergyForm, PoirierTarantola3rd(100, 0.0006, 3.7, -323), volumes, energies),
         PoirierTarantola3rd(224.509208, 0.000635892264159838, 3.690448, -323.41773);
         atol = 1e-5
     )
-    # @test lsqfit(EnergyRelation, PoirierTarantola4th(220, 0.0006, 3.7, -5500, -323), volumes, energies; lower = Float64[220, 0, 3, -6000, -400], upper = Float64[300, 0.01, 5, -5000, -300]) ≈ PoirierTarantola4th(224.430182, 0.0006232241765069493, 3.758360, -5493.859729817176, -323.417712)
+    # @test lsqfit(EnergyForm, PoirierTarantola4th(220, 0.0006, 3.7, -5500, -323), volumes, energies; lower = Float64[220, 0, 3, -6000, -400], upper = Float64[300, 0.01, 5, -5000, -300]) ≈ PoirierTarantola4th(224.430182, 0.0006232241765069493, 3.758360, -5493.859729817176, -323.417712)
 end

--- a/test/NonlinearFitting.jl
+++ b/test/NonlinearFitting.jl
@@ -55,22 +55,22 @@ end
 @testset "Test fitting bulk modulus with different element types" begin
     result = BirchMurnaghan3rd(7.218928431312577, 5.007900469653902, 4.06037725509478, 0.0)
     @test isapprox(
-        lsqfit(BulkModulusRelation, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        lsqfit(BulkModulusForm, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(BulkModulusRelation, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
+        lsqfit(BulkModulusForm, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(BulkModulusRelation, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]),
+        lsqfit(BulkModulusForm, BirchMurnaghan3rd(1, 2, 3.0, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7.0]),
         result;
         atol = 1e-5
     )
     @test isapprox(
-        lsqfit(BulkModulusRelation, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        lsqfit(BulkModulusForm, BirchMurnaghan3rd(1, 2, 3, 0), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
         result;
         atol = 1e-5
     )


### PR DESCRIPTION
This change is made based on several decisions to improve the code's logic and readability.

## Changes
1. Rename `EquationOfStateRelation`, `EnergyRelation`, `PressureRelation`, `BulkModulusRelation` to `EquationOfStateForm`, `EnergyForm`, `PressureForm`, `BulkModulusForm`, respectively.
2. Rename `calculate` to `apply`. This is a big decision.
3. Use `EnergyForm`, `PressureForm`, `BulkModulusForm`'s instances, not themselves, to dispatch the methods: `apply`, `lsqfit` and `find_volume`.

## Why the changes?
1. "relation" is between 2 things. Here, energy and volume, pressure and volume, or bulk modulus and volume, respectively. However, `EnergyRelation`, `PressureRelation`, `BulkModulusRelation` do not reflect they are with respect to volumes. So it may confuse users. On the other hand, `EnergyForm`, `PressureForm`, `BulkModulusForm` are just part of the phrases "energy form of the equation of state", "pressure form of the equation of state", "bulk modulus form of the equation of state". They do not need to have a `Volume` in their names.

2. Consider the following method:
   ```julia
   calculate(::EnergyForm, eos::Murnaghan)
   ```
   
   It does not `calculate` anything! The only thing it does is to generate a new function which takes a single parameter `v` and returns a `Real`. It is inappropriate to give it the name `calculate`. However,
   
   ```julia
   apply(::EnergyForm, eos::Murnaghan)
   ```
   
   can be read as "apply the energy form to a Murnaghan equation of state". It is a working English sentence! And
   
   ```julia
   apply(::EnergyForm, eos::Murnaghan, v::Real)
   ```
   
   can be read as "apply the energy form of a Murnaghan equation of state on volume". It is also a working English sentence! In this word order, a user can remember the parameters' order.
   
3. In [this](https://discourse.julialang.org/t/should-i-dispatch-on-singleton-types-or-their-instances/28204) question I asked, some developer suggests

   > Often the context suggests a preferred method: eg if the type is a container but is meaningful for some method without its contents (eg `convert`), or the contents are not relevant for some kind of information (`Base.IteratorSize`), or no value is available at some point (eg you are just creating an instance).

   which is quite reasonable. What's more, in [another](https://discourse.julialang.org/t/singleton-types-vs-instances-as-type-parameters/2802) question, people have [argued](https://discourse.julialang.org/t/singleton-types-vs-instances-as-type-parameters/2802/2) the benefits of using instances over types to dispatch methods. Besides, Julia doc [says](https://docs.julialang.org/en/v1/manual/types/#"Value-types"-1)
   
   > For consistency across Julia, the call site should always pass a `Val`*instance* rather than using a *type*, i.e., use `foo(Val(:bar))` rather than `foo(Val{:bar})`.
   
   So it might be a good idea to adopt this change.