### PR TITLE
Fix `findvolume` function

### DIFF
--- a/src/FindVolume.jl
+++ b/src/FindVolume.jl
@@ -18,9 +18,9 @@ using EquationsOfState.Collections
 
 export findvolume
 
-function findvolume(form::EquationOfStateForm, eos::EquationOfState, y::Real, interval, method)
+function findvolume(form::EquationOfStateForm, eos::EquationOfState, y::Real, closepoint::Real, method)
     f(v) = apply(form, eos, v) - y
-    return find_zero(f, (minimum(interval), maximum(interval)), method)
+    return find_zero(f, closepoint, method)
 end # function findvolume
 
 end


### PR DESCRIPTION
`findvolume` function's initial value is one figure, not interval