### PR TITLE
Rewrite `findvolume` methods 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 julia = "1"

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -14,10 +14,9 @@ module Collections
 using InteractiveUtils
 using Parameters
 using StaticArrays: FieldVector, Size
+import StaticArrays
 
 using EquationsOfState
-
-import StaticArrays: similar_type
 
 export apply,
        EquationOfState,
@@ -32,8 +31,7 @@ export apply,
        PoirierTarantola4th,
        Vinet,
        AntonSchmidt,
-       BreenanStacey,
-       similar_type
+       BreenanStacey
 
 # ============================================================================ #
 #                                     Types                                    #
@@ -703,7 +701,7 @@ nonabstract(T::Type)::Vector{Type} = filter(!isabstracttype, allsubtypes(T))
 
 for E in nonabstract(EquationOfState)
     eval(quote
-        similar_type(::Type{A}, ::Type{T}, size::Size{(fieldcount($E),)}) where {A<:$E,T} = $E{T}
+        StaticArrays.similar_type(::Type{A}, ::Type{T}, size::Size{(fieldcount($E),)}) where {A<:$E,T} = $E{T}
     end)
 end
 

--- a/src/EquationsOfState.jl
+++ b/src/EquationsOfState.jl
@@ -1,13 +1,6 @@
 module EquationsOfState
 
-export EquationOfStateForm, EnergyForm, PressureForm, BulkModulusForm
-
-abstract type EquationOfStateForm end
-
-struct EnergyForm <: EquationOfStateForm end
-struct PressureForm <: EquationOfStateForm end
-struct BulkModulusForm <: EquationOfStateForm end
-
+include("prelude.jl")
 include("Collections.jl")
 include("NonlinearFitting.jl")
 include("FiniteStrains.jl")

--- a/src/FindVolume.jl
+++ b/src/FindVolume.jl
@@ -65,10 +65,10 @@ function findvolume(
         Newton;
         subtypes(AbstractSecant)
     ]
+        @info("Using method \"$T\"...")
         try
-            findvolume(form, eos, y, domain, T())
-        catch
-            BoundsError, ConvergenceFailed
+            return findvolume(form, eos, y, domain, T())
+        catch BoundsError, ConvergenceFailed
             @info("Method \"$T\" failed!")
             continue
         end

--- a/src/FindVolume.jl
+++ b/src/FindVolume.jl
@@ -11,6 +11,7 @@ julia>
 """
 module FindVolume
 
+using InteractiveUtils: subtypes
 using Statistics: median
 
 using Roots: find_zero,

--- a/src/FindVolume.jl
+++ b/src/FindVolume.jl
@@ -18,9 +18,9 @@ using EquationsOfState.Collections
 
 export findvolume
 
-function findvolume(form::EquationOfStateForm, eos::EquationOfState, y::Real, interval, method)
+function findvolume(form::EquationOfStateForm, eos::EquationOfState, y::Real, closepoint::Real, method)
     f(v) = apply(form, eos, v) - y
-    return find_zero(f, (minimum(interval), maximum(interval)), method)
+    return find_zero(f, closepoint, method)
 end # function findvolume
 
 end

--- a/src/FindVolume.jl
+++ b/src/FindVolume.jl
@@ -68,8 +68,8 @@ function findvolume(
         @info("Using method \"$T\"...")
         try
             return findvolume(form, eos, y, domain, T())
-        catch BoundsError, ConvergenceFailed
-            @info("Method \"$T\" failed!")
+        catch e
+            @info("Method \"$T\" failed because of $e.")
             continue
         end
     end

--- a/src/FindVolume.jl
+++ b/src/FindVolume.jl
@@ -26,8 +26,8 @@ using Roots: find_zero,
              Newton,
              ConvergenceFailed
 
-using EquationsOfState
-using EquationsOfState.Collections
+import ..EquationOfStateForm
+using ..Collections: EquationOfState, apply
 
 export findvolume
 

--- a/src/FindVolume.jl
+++ b/src/FindVolume.jl
@@ -11,16 +11,67 @@ julia>
 """
 module FindVolume
 
-using Roots: find_zero
+using Statistics: median
+
+using Roots: find_zero,
+             AbstractBracketing,
+             AbstractNonBracketing,
+             AbstractHalleyLikeMethod,
+             AbstractNewtonLikeMethod,
+             AbstractAlefeldPotraShi,
+             AbstractBisection,
+             AbstractSecant,
+             Brent,
+             Newton,
+             ConvergenceFailed
 
 using EquationsOfState
 using EquationsOfState.Collections
 
 export findvolume
 
-function findvolume(form::EquationOfStateForm, eos::EquationOfState, y::Real, closepoint::Real, method)
+function findvolume(
+    form::EquationOfStateForm,
+    eos::EquationOfState,
+    y::Real,
+    domain::Union{AbstractVector,Tuple},
+    method::AbstractBracketing
+)
     f(v) = apply(form, eos, v) - y
-    return find_zero(f, closepoint, method)
+    return find_zero(f, (minimum(domain), maximum(domain)), method)
+end # function findvolume
+function findvolume(
+    form::EquationOfStateForm,
+    eos::EquationOfState,
+    y::Real,
+    domain::Union{AbstractVector,Tuple},
+    method::Union{AbstractNonBracketing,AbstractHalleyLikeMethod,AbstractNewtonLikeMethod}
+)
+    f(v) = apply(form, eos, v) - y
+    return find_zero(f, median(domain), method)
+end # function findvolume
+function findvolume(
+    form::EquationOfStateForm,
+    eos::EquationOfState,
+    y::Real,
+    domain::Union{AbstractVector,Tuple}
+)
+    for T in [
+        subtypes(AbstractAlefeldPotraShi);
+        subtypes(AbstractBisection);
+        Brent;
+        subtypes(AbstractHalleyLikeMethod);
+        Newton;
+        subtypes(AbstractSecant)
+    ]
+        try
+            findvolume(form, eos, y, domain, T())
+        catch
+            BoundsError, ConvergenceFailed
+            @info("Method \"$T\" failed!")
+            continue
+        end
+    end
 end # function findvolume
 
 end

--- a/src/LinearFitting.jl
+++ b/src/LinearFitting.jl
@@ -15,7 +15,7 @@ using LinearAlgebra: dot
 using Polynomials: polyder, polyfit, degree, coeffs, Poly
 using MLStyle: @match
 
-using EquationsOfState.FiniteStrains
+using ..FiniteStrains
 
 export energy_strain_expansion,
        energy_strain_derivative,

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -12,6 +12,7 @@ julia>
 module NonlinearFitting
 
 using LsqFit: curve_fit
+using StaticArrays: similar_type
 
 import ..EquationOfStateForm
 using ..Collections

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -13,8 +13,8 @@ module NonlinearFitting
 
 using LsqFit: curve_fit
 
-using EquationsOfState
-using EquationsOfState.Collections
+import ..EquationOfStateForm
+using ..Collections
 
 export lsqfit
 

--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -1,0 +1,6 @@
+export EquationOfStateForm, EnergyForm, PressureForm, BulkModulusForm
+
+abstract type EquationOfStateForm end
+struct EnergyForm <: EquationOfStateForm end
+struct PressureForm <: EquationOfStateForm end
+struct BulkModulusForm <: EquationOfStateForm end


### PR DESCRIPTION
This is an update of #20.
The methods of [Roots.jl](https://github.com/JuliaMath/Roots.jl) have the following structure:
```julia
AbstractUnivariateZeroMethod
├─ AbstractBracketing
│  ├─ AbstractAlefeldPotraShi
│  │  ├─ A42
│  │  └─ AlefeldPotraShi
│  ├─ AbstractBisection
│  │  ├─ Bisection
│  │  ├─ FalsePosition
│  │  └─ BisectionExact
│  └─ Brent
├─ AbstractHalleyLikeMethod
│  ├─ Halley
│  └─ Schroder
├─ AbstractNewtonLikeMethod
│  └─ Newton
└─ AbstractNonBracketing
   └─ AbstractSecant
      ├─ Order0
      ├─ Order16
      ├─ Order2
      ├─ Order5
      ├─ Order8
      ├─ Esser
      ├─ King
      ├─ KumarSinghAkanksha
      ├─ Order1B
      ├─ Order2B
      ├─ Secant
      ├─ Steffensen
      ├─ Thukral16
      └─ Thukral8
```
So I separate this into 3 ways:
1. The concrete subtypes of `AbstractBracketing` (Bisection-like algorithms). They take an interval as the `domain` parameter.
2. All the other concrete subtypes (Several derivative-free methods and historic methods that require a derivative or two). They take a value as the initial value. Usually to be the closest point.
3. An "adaptive" method. Which means I traverse all the methods, and see if anyone could get a solution. So the `method` parameter is omitted. (This could be used in Express.jl because it does not require a user to specify one method manually.)

Try to use these methods and see if it works @searchengineorientprogramming.