### PR TITLE
Deprecate the multiple-type-parameter EOS

### DIFF
--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -12,7 +12,7 @@ julia>
 module Collections
 
 using InteractiveUtils
-using Unitful: AbstractQuantity, @u_str, Dimension, Dimensions
+using Unitful: AbstractQuantity, @u_str, Dimension, Dimensions, upreferred
 import Unitful
 
 using EquationsOfState
@@ -69,10 +69,9 @@ function Murnaghan(v0, b0, bp0, e0)
     T = Base.promote_typeof(v0, b0, bp0, e0)
     return Murnaghan{T}(convert.(T, [v0, b0, bp0, e0])...)
 end
-Murnaghan(v0::Real, b0::Real, bp0::Real) =
-    Murnaghan(v0, b0, bp0, zero(Base.promote_typeof(v0, b0, bp0)))
-Murnaghan(v0::AbstractQuantity{A}, b0::AbstractQuantity{B}, bp0::AbstractQuantity{C}) where {A,B,C} =
-    Murnaghan(v0, b0, bp0, zero(promote_type(A, B, C)) * u"eV")
+Murnaghan(v0::Real, b0::Real, bp0::Real) = Murnaghan(v0, b0, bp0, 0)
+Murnaghan(v0::AbstractQuantity, b0::AbstractQuantity, bp0) =
+    Murnaghan(v0, b0, bp0, 0 * upreferred(Unitful.J))
 
 """
     BirchMurnaghan2nd(v0, b0, e0=0)
@@ -89,9 +88,13 @@ struct BirchMurnaghan2nd{T} <: FiniteStrainEquationOfState{T}
     b0::T
     e0::T
 end
+function BirchMurnaghan2nd(v0, b0, e0)
+    T = Base.promote_typeof(v0, b0, e0)
+    return BirchMurnaghan2nd{T}(convert.(T, [v0, b0, e0])...)
+end
 BirchMurnaghan2nd(v0::Real, b0::Real) = BirchMurnaghan2nd(v0, b0, 0)
 BirchMurnaghan2nd(v0::AbstractQuantity, b0::AbstractQuantity) =
-    BirchMurnaghan2nd(v0, b0, 0 * u"eV")
+    BirchMurnaghan2nd(v0, b0, 0 * upreferred(Unitful.J))
 
 """
     BirchMurnaghan3rd(v0, b0, bp0, e0=0)
@@ -110,9 +113,13 @@ struct BirchMurnaghan3rd{T} <: FiniteStrainEquationOfState{T}
     bp0::T
     e0::T
 end
+function BirchMurnaghan3rd(v0, b0, bp0, e0)
+    T = Base.promote_typeof(v0, b0, bp0, e0)
+    return BirchMurnaghan3rd{T}(convert.(T, [v0, b0, bp0, e0])...)
+end
 BirchMurnaghan3rd(v0::Real, b0::Real, bp0::Real) = BirchMurnaghan3rd(v0, b0, bp0, 0)
-BirchMurnaghan3rd(v0::AbstractQuantity, b0::AbstractQuantity, bp0::AbstractQuantity) =
-    BirchMurnaghan3rd(v0, b0, bp0, 0 * u"eV")
+BirchMurnaghan3rd(v0::AbstractQuantity, b0::AbstractQuantity, bp0) =
+    BirchMurnaghan3rd(v0, b0, bp0, 0 * upreferred(Unitful.J))
 
 """
     BirchMurnaghan4th(v0, b0, bp0, bpp0, e0=0)
@@ -133,14 +140,18 @@ struct BirchMurnaghan4th{T} <: FiniteStrainEquationOfState{T}
     bpp0::T
     e0::T
 end
+function BirchMurnaghan4th(v0, b0, bp0, bpp0, e0)
+    T = Base.promote_typeof(v0, b0, bp0, bpp0, e0)
+    return BirchMurnaghan4th{T}(convert.(T, [v0, b0, bp0, bpp0, e0])...)
+end
 BirchMurnaghan4th(v0::Real, b0::Real, bp0::Real, bpp0::Real) =
     BirchMurnaghan4th(v0, b0, bp0, bpp0, 0)
 BirchMurnaghan4th(
     v0::AbstractQuantity,
     b0::AbstractQuantity,
-    bp0::AbstractQuantity,
+    bp0,
     bpp0::AbstractQuantity,
-) = BirchMurnaghan4th(v0, b0, bp0, bpp0, 0 * u"eV")
+) = BirchMurnaghan4th(v0, b0, bp0, bpp0, 0 * upreferred(Unitful.J))
 
 """
     PoirierTarantola2nd(v0, b0, e0=0)
@@ -157,9 +168,13 @@ struct PoirierTarantola2nd{T} <: FiniteStrainEquationOfState{T}
     b0::T
     e0::T
 end
+function PoirierTarantola2nd(v0, b0, e0)
+    T = Base.promote_typeof(v0, b0, e0)
+    return PoirierTarantola2nd{T}(convert.(T, [v0, b0, e0])...)
+end
 PoirierTarantola2nd(v0::Real, b0::Real) = PoirierTarantola2nd(v0, b0, 0)
 PoirierTarantola2nd(v0::AbstractQuantity, b0::AbstractQuantity) =
-    PoirierTarantola2nd(v0, b0, 0 * u"eV")
+    PoirierTarantola2nd(v0, b0, 0 * upreferred(Unitful.J))
 
 """
     PoirierTarantola3rd(v0, b0, bp0, e0=0)
@@ -178,9 +193,13 @@ struct PoirierTarantola3rd{T} <: FiniteStrainEquationOfState{T}
     bp0::T
     e0::T
 end
+function PoirierTarantola3rd(v0, b0, bp0, e0)
+    T = Base.promote_typeof(v0, b0, bp0, e0)
+    return PoirierTarantola3rd{T}(convert.(T, [v0, b0, bp0, e0])...)
+end
 PoirierTarantola3rd(v0::Real, b0::Real, bp0::Real) = PoirierTarantola3rd(v0, b0, bp0, 0)
-PoirierTarantola3rd(v0::AbstractQuantity, b0::AbstractQuantity, bp0::AbstractQuantity) =
-    PoirierTarantola3rd(v0, b0, bp0, 0 * u"eV")
+PoirierTarantola3rd(v0::AbstractQuantity, b0::AbstractQuantity, bp0) =
+    PoirierTarantola3rd(v0, b0, bp0, 0 * upreferred(Unitful.J))
 
 """
     PoirierTarantola4th(v0, b0, bp0, bpp0, e0=0)
@@ -201,14 +220,18 @@ struct PoirierTarantola4th{T} <: FiniteStrainEquationOfState{T}
     bpp0::T
     e0::T
 end
+function PoirierTarantola4th(v0, b0, bp0, bpp0, e0)
+    T = Base.promote_typeof(v0, b0, bp0, bpp0, e0)
+    return PoirierTarantola4th{T}(convert.(T, [v0, b0, bp0, bpp0, e0])...)
+end
 PoirierTarantola4th(v0::Real, b0::Real, bp0::Real, bpp0::Real) =
     PoirierTarantola4th(v0, b0, bp0, bpp0, 0)
 PoirierTarantola4th(
     v0::AbstractQuantity,
     b0::AbstractQuantity,
-    bp0::AbstractQuantity,
+    bp0,
     bpp0::AbstractQuantity,
-) = PoirierTarantola4th(v0, b0, bp0, bpp0, 0 * u"eV")
+) = PoirierTarantola4th(v0, b0, bp0, bpp0, 0 * upreferred(Unitful.J))
 
 """
     Vinet(v0, b0, bp0, e0=0)
@@ -227,9 +250,13 @@ struct Vinet{T} <: EquationOfState{T}
     bp0::T
     e0::T
 end
+function Vinet(v0, b0, bp0, e0)
+    T = Base.promote_typeof(v0, b0, bp0, e0)
+    return Vinet{T}(convert.(T, [v0, b0, bp0, e0])...)
+end
 Vinet(v0::Real, b0::Real, bp0::Real) = Vinet(v0, b0, bp0, 0)
-Vinet(v0::AbstractQuantity, b0::AbstractQuantity, bp0::AbstractQuantity) =
-    Vinet(v0, b0, bp0, 0 * u"eV")
+Vinet(v0::AbstractQuantity, b0::AbstractQuantity, bp0) =
+    Vinet(v0, b0, bp0, 0 * upreferred(Unitful.J))
 
 struct AntonSchmidt{T} <: EquationOfState{T}
     v0::T

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -36,18 +36,18 @@ export apply,
 #                                     Types                                    #
 # ============================================================================ #
 """
-    EquationOfState
+    EquationOfState{T}
 
 An abstraction of equations of state, where `T` specifies the elements' type.
 """
-abstract type EquationOfState end
+abstract type EquationOfState{T} end
 
 """
-    FiniteStrainEquationOfState <: EquationOfState
+    FiniteStrainEquationOfState{T} <: EquationOfState{T}
 
 An abstraction of finite strain equations of state.
 """
-abstract type FiniteStrainEquationOfState <: EquationOfState end
+abstract type FiniteStrainEquationOfState{T} <: EquationOfState{T} end
 
 """
     Murnaghan(v0, b0, bp0, e0=0)
@@ -60,15 +60,20 @@ Create a Murnaghan equation of state. The elements' type will be handled automat
 - `bp0`: the first-order pressure-derivative bulk modulus of solid at zero pressure.
 - `e0=0`: the energy of solid at zero pressure. By default is `0`.
 """
-struct Murnaghan{A,B,C,D} <: EquationOfState
-    v0::A
-    b0::B
-    bp0::C
-    e0::D
+struct Murnaghan{T} <: EquationOfState{T}
+    v0::T
+    b0::T
+    bp0::T
+    e0::T
 end
-Murnaghan(v0::Real, b0::Real, bp0::Real) = Murnaghan(v0, b0, bp0, 0)
-Murnaghan(v0::AbstractQuantity, b0::AbstractQuantity, bp0::AbstractQuantity) =
-    Murnaghan(v0, b0, bp0, 0 * u"eV")
+function Murnaghan(v0, b0, bp0, e0)
+    T = Base.promote_typeof(v0, b0, bp0, e0)
+    return Murnaghan{T}(map(x -> convert(T, x), (v0, b0, bp0, e0))...)
+end
+Murnaghan(v0::Real, b0::Real, bp0::Real) =
+    Murnaghan(v0, b0, bp0, zero(Base.promote_typeof(v0, b0, bp0)))
+Murnaghan(v0::AbstractQuantity{A}, b0::AbstractQuantity{B}, bp0::AbstractQuantity{C}) where {A,B,C} =
+    Murnaghan(v0, b0, bp0, zero(promote_type(A, B, C)) * u"eV")
 
 """
     BirchMurnaghan2nd(v0, b0, e0=0)
@@ -80,10 +85,10 @@ Create a Birch–Murnaghan 2nd order equation of state. The elements' type will 
 - `b0`: the bulk modulus of solid at zero pressure.
 - `e0=0`: the energy of solid at zero pressure. By default is `0`.
 """
-struct BirchMurnaghan2nd{A,B,C} <: FiniteStrainEquationOfState
-    v0::A
-    b0::B
-    e0::C
+struct BirchMurnaghan2nd{T} <: FiniteStrainEquationOfState{T}
+    v0::T
+    b0::T
+    e0::T
 end
 BirchMurnaghan2nd(v0::Real, b0::Real) = BirchMurnaghan2nd(v0, b0, 0)
 BirchMurnaghan2nd(v0::AbstractQuantity, b0::AbstractQuantity) =
@@ -100,11 +105,11 @@ Create a Birch–Murnaghan 3rd order equation of state. The elements' type will 
 - `bp0`: the first-order pressure-derivative bulk modulus of solid at zero pressure.
 - `e0=0`: the energy of solid at zero pressure. By default is `0`.
 """
-struct BirchMurnaghan3rd{A,B,C,D} <: FiniteStrainEquationOfState
-    v0::A
-    b0::B
-    bp0::C
-    e0::D
+struct BirchMurnaghan3rd{T} <: FiniteStrainEquationOfState{T}
+    v0::T
+    b0::T
+    bp0::T
+    e0::T
 end
 BirchMurnaghan3rd(v0::Real, b0::Real, bp0::Real) = BirchMurnaghan3rd(v0, b0, bp0, 0)
 BirchMurnaghan3rd(v0::AbstractQuantity, b0::AbstractQuantity, bp0::AbstractQuantity) =
@@ -122,12 +127,12 @@ Create a Birch–Murnaghan 4th order equation of state. The elements' type will 
 - `bpp0`: the second-order pressure-derivative bulk modulus of solid at zero pressure.
 - `e0=0`: the energy of solid at zero pressure. By default is `0`.
 """
-struct BirchMurnaghan4th{A,B,C,D,E} <: FiniteStrainEquationOfState
-    v0::A
-    b0::B
-    bp0::C
-    bpp0::D
-    e0::E
+struct BirchMurnaghan4th{T} <: FiniteStrainEquationOfState{T}
+    v0::T
+    b0::T
+    bp0::T
+    bpp0::T
+    e0::T
 end
 BirchMurnaghan4th(v0::Real, b0::Real, bp0::Real, bpp0::Real) =
     BirchMurnaghan4th(v0, b0, bp0, bpp0, 0)
@@ -148,10 +153,10 @@ Create a Poirier–Tarantola order equation of state. The elements' type will be
 - `b0`: the bulk modulus of solid at zero pressure.
 - `e0=0`: the energy of solid at zero pressure. By default is `0`.
 """
-struct PoirierTarantola2nd{A,B,C} <: FiniteStrainEquationOfState
-    v0::A
-    b0::B
-    e0::C
+struct PoirierTarantola2nd{T} <: FiniteStrainEquationOfState{T}
+    v0::T
+    b0::T
+    e0::T
 end
 PoirierTarantola2nd(v0::Real, b0::Real) = PoirierTarantola2nd(v0, b0, 0)
 PoirierTarantola2nd(v0::AbstractQuantity, b0::AbstractQuantity) =
@@ -168,11 +173,11 @@ Create a Poirier–Tarantola 3rd order equation of state. The elements' type wil
 - `bp0`: the first-order pressure-derivative bulk modulus of solid at zero pressure.
 - `e0=0`: the energy of solid at zero pressure. By default is `0`.
 """
-struct PoirierTarantola3rd{A,B,C,D} <: FiniteStrainEquationOfState
-    v0::A
-    b0::B
-    bp0::C
-    e0::D
+struct PoirierTarantola3rd{T} <: FiniteStrainEquationOfState{T}
+    v0::T
+    b0::T
+    bp0::T
+    e0::T
 end
 PoirierTarantola3rd(v0::Real, b0::Real, bp0::Real) = PoirierTarantola3rd(v0, b0, bp0, 0)
 PoirierTarantola3rd(v0::AbstractQuantity, b0::AbstractQuantity, bp0::AbstractQuantity) =
@@ -190,12 +195,12 @@ Create a Birch–Murnaghan 4th order equation of state. The elements' type will 
 - `bpp0`: the second-order pressure-derivative bulk modulus of solid at zero pressure.
 - `e0=0`: the energy of solid at zero pressure. By default is `0`.
 """
-struct PoirierTarantola4th{A,B,C,D,E} <: FiniteStrainEquationOfState
-    v0::A
-    b0::B
-    bp0::C
-    bpp0::D
-    e0::E
+struct PoirierTarantola4th{T} <: FiniteStrainEquationOfState{T}
+    v0::T
+    b0::T
+    bp0::T
+    bpp0::T
+    e0::T
 end
 PoirierTarantola4th(v0::Real, b0::Real, bp0::Real, bpp0::Real) =
     PoirierTarantola4th(v0, b0, bp0, bpp0, 0)
@@ -217,29 +222,29 @@ Create a Vinet equation of state. The elements' type will be handled automatical
 - `bp0`: the first-order pressure-derivative bulk modulus of solid at zero pressure.
 - `e0=0`: the energy of solid at zero pressure. By default is `0`.
 """
-struct Vinet{A,B,C,D} <: EquationOfState
-    v0::A
-    b0::B
-    bp0::C
-    e0::D
+struct Vinet{T} <: EquationOfState{T}
+    v0::T
+    b0::T
+    bp0::T
+    e0::T
 end
 Vinet(v0::Real, b0::Real, bp0::Real) = Vinet(v0, b0, bp0, 0)
 Vinet(v0::AbstractQuantity, b0::AbstractQuantity, bp0::AbstractQuantity) =
     Vinet(v0, b0, bp0, 0 * u"eV")
 
-struct AntonSchmidt{A,B,C,D} <: EquationOfState
-    v0::A
-    β::B
-    n::C
-    e∞::D
+struct AntonSchmidt{T} <: EquationOfState{T}
+    v0::T
+    β::T
+    n::T
+    e∞::T
 end
 AntonSchmidt(v0::Real, β::Real, n::Real) = AntonSchmidt(v0, β, n, 0)
 
-struct BreenanStacey{A,B,C,D} <: EquationOfState
-    v0::A
-    b0::B
-    γ0::C
-    e0::D
+struct BreenanStacey{T} <: EquationOfState{T}
+    v0::T
+    b0::T
+    γ0::T
+    e0::T
 end
 BreenanStacey(v0::Real, b0::Real, γ0::Real) = BreenanStacey(v0, b0, γ0, 0)
 # =================================== Types ================================== #

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -67,7 +67,7 @@ struct Murnaghan{T} <: EquationOfState{T}
 end
 function Murnaghan(v0, b0, bp0, e0)
     T = Base.promote_typeof(v0, b0, bp0, e0)
-    return Murnaghan{T}(map(x -> convert(T, x), (v0, b0, bp0, e0))...)
+    return Murnaghan{T}(convert.(T, [v0, b0, bp0, e0])...)
 end
 Murnaghan(v0::Real, b0::Real, bp0::Real) =
     Murnaghan(v0, b0, bp0, zero(Base.promote_typeof(v0, b0, bp0)))
@@ -666,8 +666,6 @@ end
 # ============================================================================ #
 # This is a helper function and should not be exported.
 fieldvalues(eos::EquationOfState) = [getfield(eos, i) for i in 1:nfields(eos)]
-
-Base.eltype(T::Type{<:EquationOfState}) = promote_type(T.types...)
 
 Unitful.upreferred(::Dimensions{(
     Dimension{:Length}(2 // 1),

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -264,6 +264,10 @@ struct AntonSchmidt{T} <: EquationOfState{T}
     n::T
     e∞::T
 end
+function AntonSchmidt(v0, β, n, e∞)
+    T = Base.promote_typeof(v0, β, n, e∞)
+    return AntonSchmidt{T}(convert.(T, [v0, β, n, e∞])...)
+end
 AntonSchmidt(v0::Real, β::Real, n::Real) = AntonSchmidt(v0, β, n, 0)
 
 struct BreenanStacey{T} <: EquationOfState{T}
@@ -271,6 +275,10 @@ struct BreenanStacey{T} <: EquationOfState{T}
     b0::T
     γ0::T
     e0::T
+end
+function BreenanStacey(v0, b0, γ0, e0)
+    T = Base.promote_typeof(v0, b0, γ0, e0)
+    return BreenanStacey{T}(convert.(T, [v0, b0, γ0, e0])...)
 end
 BreenanStacey(v0::Real, b0::Real, γ0::Real) = BreenanStacey(v0, b0, γ0, 0)
 # =================================== Types ================================== #

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -15,7 +15,7 @@ using InteractiveUtils
 using Unitful: AbstractQuantity, @u_str, Dimension, Dimensions, upreferred
 import Unitful
 
-using EquationsOfState
+using EquationsOfState: EnergyForm, PressureForm, BulkModulusForm
 
 export apply,
        EquationOfState,

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -41,7 +41,7 @@ function lsqfit(
     debug = false,
     kwargs...,
 )
-    T = promote_type(eltype(eos), eltype(xdata), eltype(ydata), Float64)
+    T = promote_type(eltype(xdata), eltype(ydata), Float64)
     E = constructorof(typeof(eos))
     model = (x, p) -> map(apply(form, E(p...)), x)
     fitted = curve_fit(

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -20,14 +20,6 @@ using ..Collections
 
 export lsqfit
 
-# This idea is borrowed from [SimpleTraits.jl](https://github.com/mauro3/SimpleTraits.jl/blob/master/src/SimpleTraits.jl).
-abstract type Trait end
-abstract type Not{T<:Trait} <: Trait end
-struct HasUnit <: Trait end
-
-_unit_trait(T::Type{<:Real}) = Not{HasUnit}
-_unit_trait(T::Type{<:AbstractQuantity}) = HasUnit
-
 """
     lsqfit(form, eos, xdata, ydata; debug = false, kwargs...)
 
@@ -43,20 +35,9 @@ Fit an equation of state using least-squares fitting method (with the Levenberg-
 """
 function lsqfit(
     form::EquationForm,
-    eos::EquationOfState,
-    xdata::AbstractVector,
-    ydata::AbstractVector;
-    kwargs...,
-)
-    T = promote_type(eltype(eos), eltype(xdata), eltype(ydata))
-    return lsqfit(_unit_trait(T), form, eos, xdata, ydata, kwargs...)
-end # function lsqfit
-function lsqfit(
-    ::Type{Not{HasUnit}},
-    form::EquationForm,
-    eos::EquationOfState,
-    xdata::AbstractVector,
-    ydata::AbstractVector;
+    eos::EquationOfState{<:Real},
+    xdata::AbstractVector{<:Real},
+    ydata::AbstractVector{<:Real};
     debug = false,
     kwargs...,
 )
@@ -73,11 +54,10 @@ function lsqfit(
     return debug ? fitted : E(fitted.param...)
 end  # function lsqfit
 function lsqfit(
-    ::Type{HasUnit},
     form::EquationForm,
-    eos::EquationOfState,
-    xdata::AbstractVector,
-    ydata::AbstractVector;
+    eos::EquationOfState{<:AbstractQuantity},
+    xdata::AbstractVector{<:AbstractQuantity},
+    ydata::AbstractVector{<:AbstractQuantity};
     kwargs...,
 )
     E = constructorof(typeof(eos))

--- a/src/NonlinearFitting.jl
+++ b/src/NonlinearFitting.jl
@@ -64,7 +64,7 @@ function lsqfit(
     values = Collections.fieldvalues(eos)
     original_units = map(unit, values)
     trial_params, xdata, ydata = [map(ustrip ∘ upreferred, x) for x in (values, xdata, ydata)]
-    result = lsqfit(form, E(trial_params...), xdata, ydata, kwargs...)
+    result = lsqfit(form, E(trial_params...), xdata, ydata; kwargs...)
     if result isa EquationOfState
         data = Collections.fieldvalues(result)
         return E(

--- a/test/Collections.jl
+++ b/test/Collections.jl
@@ -1,0 +1,29 @@
+using Test
+
+using EquationsOfState.Collections
+
+@testset "Test EOS promotion" begin
+    @test typeof(Murnaghan(1, 2, 3.0, 0)) == Murnaghan{Float64}
+    @test typeof(BirchMurnaghan2nd(1, 2.0, 0)) == BirchMurnaghan2nd{Float64}
+    @test typeof(BirchMurnaghan3rd(1, 2, 3.0, 0)) == BirchMurnaghan3rd{Float64}
+    @test typeof(BirchMurnaghan4th(1, 2.0, 3, 4, 0)) == BirchMurnaghan4th{Float64}
+    @test typeof(Vinet(1, 2, 3.0, 0)) == Vinet{Float64}
+    @test typeof(PoirierTarantola2nd(1, 2.0, 0)) == PoirierTarantola2nd{Float64}
+    @test typeof(PoirierTarantola3rd(1, 2, 3.0, 0)) == PoirierTarantola3rd{Float64}
+    @test typeof(PoirierTarantola4th(1, 2, 3, 4, 0)) == PoirierTarantola4th{Int}
+    @test typeof(AntonSchmidt(1, 2, 3.0, 0)) == AntonSchmidt{Float64}
+    @test typeof(BreenanStacey(1, 2, 3.0, 0)) == BreenanStacey{Float64}
+end
+
+@testset "Test default EOS parameter `e0` and promotion" begin
+    @test Murnaghan(1, 2, 3.0) == Murnaghan(1.0, 2.0, 3.0, 0.0)
+    @test BirchMurnaghan2nd(1, 2.0) == BirchMurnaghan2nd(1.0, 2.0, 0.0)
+    @test BirchMurnaghan3rd(1, 2, 3.0) == BirchMurnaghan3rd(1.0, 2.0, 3.0, 0.0)
+    @test BirchMurnaghan4th(1, 2.0, 3, 4) == BirchMurnaghan4th(1.0, 2.0, 3.0, 4.0, 0.0)
+    @test Vinet(1, 2, 3.0) == Vinet(1.0, 2.0, 3.0, 0.0)
+    @test PoirierTarantola2nd(1, 2.0) == PoirierTarantola2nd(1.0, 2.0, 0.0)
+    @test PoirierTarantola3rd(1, 2, 3.0) == PoirierTarantola3rd(1.0, 2.0, 3.0, 0.0)
+    @test PoirierTarantola4th(1, 2, 3, 4) == PoirierTarantola4th(1, 2, 3, 4, 0)
+    @test AntonSchmidt(1, 2, 3.0) == AntonSchmidt(1.0, 2.0, 3.0, 0.0)
+    @test BreenanStacey(1, 2, 3.0) == BreenanStacey(1.0, 2.0, 3.0, 0.0)
+end

--- a/test/Collections.jl
+++ b/test/Collections.jl
@@ -1,5 +1,7 @@
 using Test
 
+using Unitful
+
 using EquationsOfState.Collections
 
 @testset "Test EOS promotion" begin
@@ -13,6 +15,10 @@ using EquationsOfState.Collections
     @test typeof(PoirierTarantola4th(1, 2, 3, 4, 0)) == PoirierTarantola4th{Int}
     @test typeof(AntonSchmidt(1, 2, 3.0, 0)) == AntonSchmidt{Float64}
     @test typeof(BreenanStacey(1, 2, 3.0, 0)) == BreenanStacey{Float64}
+    @test Murnaghan(1, Int32(2), Int8(3), 0) == Murnaghan{Int64}(1, 2, 3, 0)
+    @test Murnaghan(1, 2//1, Int8(3), 0) == Murnaghan{Rational{Int64}}(1//1, 2//1, 3//1, 0//1)
+    @test typeof(Murnaghan(1u"angstrom^3", 2u"eV/angstrom^3", 3.0, 4u"eV")) == Murnaghan{Quantity{Float64}}
+    @test typeof(Murnaghan(1u"angstrom^3", 2u"eV/angstrom^3", 3//2, 4u"eV")) == Murnaghan{Quantity{Rational{Int64}}}
 end
 
 @testset "Test default EOS parameter `e0` and promotion" begin
@@ -26,4 +32,7 @@ end
     @test PoirierTarantola4th(1, 2, 3, 4) == PoirierTarantola4th(1, 2, 3, 4, 0)
     @test AntonSchmidt(1, 2, 3.0) == AntonSchmidt(1.0, 2.0, 3.0, 0.0)
     @test BreenanStacey(1, 2, 3.0) == BreenanStacey(1.0, 2.0, 3.0, 0.0)
+    @test typeof(Murnaghan(1u"angstrom^3", 2u"eV/angstrom^3", 3)) == Murnaghan{Quantity{Int64}}
+    @test typeof(Murnaghan(1u"angstrom^3", 2u"eV/angstrom^3", 3.0)) == Murnaghan{Quantity{Float64}}
+    @test typeof(Murnaghan(1.0u"angstrom^3", 2u"eV/angstrom^3", 3.0)) == Murnaghan{Quantity{Float64}}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using EquationsOfState
 using Test
 
 @testset "EquationsOfState.jl" begin
+    include("Collections.jl")
     include("FiniteStrains.jl")
     include("NonlinearFitting.jl")
     include("LinearFitting.jl")


### PR DESCRIPTION
- Use 1 single type parameter to represent the element type of an EOS.
- Deprecate `HasUnit` trait in `NonlinearFitting` module