### PR TITLE
breaking: Redesign API

### DIFF
--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -818,20 +818,10 @@ function (f::BulkModulusStyle{<:Shanker})(v)
     x = v / v0
     y = 1 - x
     t = b′0 - 8 / 3
-    return b0 / cbrt(x) * (1 + y + y^2) * exp(t * y) + 4 / 3 * pressureof(f.eos)(v)
+    return b0 / cbrt(x) * (1 + y + y^2) * exp(t * y) + 4 / 3 * PressureStyle(f.eos)(v)
 end
 
 Base.eltype(::FieldValues{<:EquationOfState{T}}) where {T} = T
 Base.eltype(::Type{<:EquationOfState{T}}) where {T} = T
-
-function Base.getproperty(eos::EquationOfState, name::Symbol)
-    if name ∈ (:bp0, :bd0)
-        return getfield(eos, :b′0)
-    elseif name ∈ (:bpp0, :bdd0)
-        return getfield(eos, :b′′0)
-    else
-        return getfield(eos, name)
-    end
-end
 
 end

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -1,6 +1,6 @@
 """
-This module provides `EquationOfState` types and calculate
-energy, pressure, or bulk modulus of an `EquationOfState` on
+This module provides `EOSParameters` types and calculate
+energy, pressure, or bulk modulus of an `EOSParameters` on
 a (an) volume (array of volumes).
 """
 module Collections
@@ -27,135 +27,23 @@ export Murnaghan,
     BreenanStacey,
     Shanker,
     PolynomialEOS,
-    EnergyStyle,
-    PressureStyle,
-    BulkModulusStyle
-
-abstract type EquationStyle{T} end
-"""
-    EnergyStyle()
-    (::EquationOfState)(::EnergyStyle)(v)
-    (::EquationOfState)(::EnergyStyle)
-
-Return the energy of an `EquationOfState` on volume `v`. If `eos` has units,
-`v` must also has.
-
-Return a [function-like object](https://docs.julialang.org/en/v1/manual/methods/#Function-like-objects-1) that takes a volume as a variable, suitable for mapping onto an array.
-
-# Examples
-```jldoctest
-julia> f = Vinet(1, 2, 3)(EnergyStyle());
-
-julia> map(f, 1:1:10)
-10-element Array{Float64,1}:
- 0.0
- 0.367905230584308
- 0.7652477289745814
- 1.0516459435179233
- 1.2560420090256408
- 1.405149833626178
- 1.5165867441792136
- 1.6017034530570884
- 1.6679539823686644
- 1.7203642945516917
-```
-
-However, these methods are preserved for special cases
-(see [#52](https://github.com/MineralsCloud/EquationsOfState.jl/issues/52#issuecomment-555856194)).
-In most cases, the Julia [`do` block syntax](http://docs.julialang.org/en/v1/base/base/#do)
-is preferred:
-```jldoctest
-julia> map(1:1:10) do v
-           Vinet(1, 2, 3)(EnergyStyle())(v)
-       end
-10-element Array{Float64,1}:
- 0.0
- 0.367905230584308
- 0.7652477289745814
- 1.0516459435179235
- 1.2560420090256412
- 1.405149833626178
- 1.5165867441792138
- 1.6017034530570884
- 1.6679539823686644
- 1.7203642945516917
-```
-"""
-struct EnergyStyle{T} <: EquationStyle{T}
-    eos::T
-end
-"""
-    PressureStyle()
-    (::EquationOfState)(::PressureStyle)(v)
-    (::EquationOfState)(::PressureStyle)
-
-Return the pressure of an `EquationOfState` on volume `v`. If `eos` has units,
-`v` must also has.
-
-# Examples
-```jldoctest
-julia> f = Vinet(1, 2, 3)(PressureStyle());
-
-julia> map(f, 1:1:10)
-10-element Array{Float64,1}:
-  0.0
- -0.45046308428750254
- -0.3384840350043251
- -0.24010297221667418
- -0.17314062272722755
- -0.12795492664586872
- -0.09677154467733216
- -0.07468060255179591
- -0.05864401631176751
- -0.04674768462396211
-```
-"""
-struct PressureStyle{T} <: EquationStyle{T}
-    eos::T
-end
-"""
-    BulkModulusStyle()
-    (::EquationOfState)(::BulkModulusStyle)(v)
-    (::EquationOfState)(::BulkModulusStyle)
-
-Return the bulk modulus of an `EquationOfState` on volume `v`. If `eos` has units,
-`v` must also has.
-
-# Examples
-```jldoctest
-julia> f = BirchMurnaghan3rd(1, 2, 3)(BulkModulusStyle());
-
-julia> map(f, 1:1:10)
-10-element Array{Float64,1}:
- 2.0
- 0.9216086833346415
- 0.444903691617472
- 0.2540009203153288
- 0.16193296566524193
- 0.11130584492987289
- 0.08076305569984538
- 0.06103515625
- 0.047609811583958425
- 0.03808959181078831
-```
-"""
-struct BulkModulusStyle{T} <: EquationStyle{T}
-    eos::T
-end
+    EnergyEquation,
+    PressureEquation,
+    BulkModulusEquation
 
 """
-    EquationOfState{T}
+    EOSParameters{T}
 
 An abstraction of equations of state, where `T` specifies the elements' common type.
 """
-abstract type EquationOfState{T} end
+abstract type EOSParameters{T} end
 
 """
-    FiniteStrainEOS{T} <: EquationOfState{T}
+    FiniteStrainEOS{T} <: EOSParameters{T}
 
 An abstraction of finite strain equations of state, where `T` specifies the elements' common type.
 """
-abstract type FiniteStrainEOS{T} <: EquationOfState{T} end
+abstract type FiniteStrainEOS{T} <: EOSParameters{T} end
 
 """
     Murnaghan(v0, b0, b′0, e0)
@@ -183,7 +71,7 @@ julia> Murnaghan(1u"nm^3", 2u"GPa", 3, 3.0u"eV")
 Murnaghan{Quantity{Float64,D,U} where U where D}(1.0 nm³, 2.0 GPa, 3.0, 3.0 eV)
 ```
 """
-@auto_hash_equals struct Murnaghan{T} <: EquationOfState{T}
+@auto_hash_equals struct Murnaghan{T} <: EOSParameters{T}
     v0::T
     b0::T
     b′0::T
@@ -560,7 +448,7 @@ julia> Vinet(1u"nm^3", 2u"GPa", 3, 4.0u"eV")
 Vinet{Quantity{Float64,D,U} where U where D}(1.0 nm³, 2.0 GPa, 3.0, 4.0 eV)
 ```
 """
-@auto_hash_equals struct Vinet{T} <: EquationOfState{T}
+@auto_hash_equals struct Vinet{T} <: EOSParameters{T}
     v0::T
     b0::T
     b′0::T
@@ -573,7 +461,7 @@ end
 Vinet(v0::Real, b0::Real, b′0::Real) = Vinet(v0, b0, b′0, 0)
 Vinet(v0::AbstractQuantity, b0::AbstractQuantity, b′0) = Vinet(v0, b0, b′0, 0 * u"eV")
 
-@auto_hash_equals struct AntonSchmidt{T} <: EquationOfState{T}
+@auto_hash_equals struct AntonSchmidt{T} <: EOSParameters{T}
     v0::T
     β::T
     n::T
@@ -585,7 +473,7 @@ function AntonSchmidt(v0, β, n, e∞)
 end
 AntonSchmidt(v0::Real, β::Real, n::Real) = AntonSchmidt(v0, β, n, 0)
 
-@auto_hash_equals struct BreenanStacey{T} <: EquationOfState{T}
+@auto_hash_equals struct BreenanStacey{T} <: EOSParameters{T}
     v0::T
     b0::T
     γ0::T
@@ -597,7 +485,7 @@ function BreenanStacey(v0, b0, γ0, e0)
 end
 BreenanStacey(v0::Real, b0::Real, γ0::Real) = BreenanStacey(v0, b0, γ0, 0)
 
-@auto_hash_equals struct Shanker{T} <: EquationOfState{T}
+@auto_hash_equals struct Shanker{T} <: EOSParameters{T}
     v0::T
     b0::T
     b′0::T
@@ -610,7 +498,7 @@ end
 Shanker(v0::Real, b0::Real, b′0::Real) = Shanker(v0, b0, b′0, 0)
 Shanker(v0::AbstractQuantity, b0::AbstractQuantity, b′0) = Shanker(v0, b0, b′0, 0 * u"eV")
 
-@auto_hash_equals struct PolynomialEOS{N,T} <: EquationOfState{T}
+@auto_hash_equals struct PolynomialEOS{N,T} <: EOSParameters{T}
     v0::T
     p0::SVector{N,T}
     e0::T
@@ -627,30 +515,142 @@ PolynomialEOS(v0::Real, p0::AbstractVector{<:Real}) = PolynomialEOS(v0, p0, 0)
 PolynomialEOS(v0::AbstractQuantity, p0::AbstractVector{<:AbstractQuantity}) =
     PolynomialEOS(v0, p0, 0 * u"eV")
 
-# EnergyStyle evaluation
-function (f::EnergyStyle{<:Murnaghan})(v)
-    v0, b0, b′0, e0 = fieldvalues(f.eos)
+abstract type EquationOfState{T<:EOSParameters} end
+"""
+    EnergyEquation()
+    (::EOSParameters)(::EnergyEquation)(v)
+    (::EOSParameters)(::EnergyEquation)
+
+Return the energy of an `EOSParameters` on volume `v`. If `eos` has units,
+`v` must also has.
+
+Return a [function-like object](https://docs.julialang.org/en/v1/manual/methods/#Function-like-objects-1) that takes a volume as a variable, suitable for mapping onto an array.
+
+# Examples
+```jldoctest
+julia> f = Vinet(1, 2, 3)(EnergyEquation());
+
+julia> map(f, 1:1:10)
+10-element Array{Float64,1}:
+ 0.0
+ 0.367905230584308
+ 0.7652477289745814
+ 1.0516459435179233
+ 1.2560420090256408
+ 1.405149833626178
+ 1.5165867441792136
+ 1.6017034530570884
+ 1.6679539823686644
+ 1.7203642945516917
+```
+
+However, these methods are preserved for special cases
+(see [#52](https://github.com/MineralsCloud/EquationsOfState.jl/issues/52#issuecomment-555856194)).
+In most cases, the Julia [`do` block syntax](http://docs.julialang.org/en/v1/base/base/#do)
+is preferred:
+```jldoctest
+julia> map(1:1:10) do v
+           Vinet(1, 2, 3)(EnergyEquation())(v)
+       end
+10-element Array{Float64,1}:
+ 0.0
+ 0.367905230584308
+ 0.7652477289745814
+ 1.0516459435179235
+ 1.2560420090256412
+ 1.405149833626178
+ 1.5165867441792138
+ 1.6017034530570884
+ 1.6679539823686644
+ 1.7203642945516917
+```
+"""
+struct EnergyEquation{T} <: EquationOfState{T}
+    params::T
+end
+"""
+    PressureEquation()
+    (::EOSParameters)(::PressureEquation)(v)
+    (::EOSParameters)(::PressureEquation)
+
+Return the pressure of an `EOSParameters` on volume `v`. If `eos` has units,
+`v` must also has.
+
+# Examples
+```jldoctest
+julia> f = Vinet(1, 2, 3)(PressureEquation());
+
+julia> map(f, 1:1:10)
+10-element Array{Float64,1}:
+  0.0
+ -0.45046308428750254
+ -0.3384840350043251
+ -0.24010297221667418
+ -0.17314062272722755
+ -0.12795492664586872
+ -0.09677154467733216
+ -0.07468060255179591
+ -0.05864401631176751
+ -0.04674768462396211
+```
+"""
+struct PressureEquation{T} <: EquationOfState{T}
+    params::T
+end
+"""
+    BulkModulusEquation()
+    (::EOSParameters)(::BulkModulusEquation)(v)
+    (::EOSParameters)(::BulkModulusEquation)
+
+Return the bulk modulus of an `EOSParameters` on volume `v`. If `eos` has units,
+`v` must also has.
+
+# Examples
+```jldoctest
+julia> f = BirchMurnaghan3rd(1, 2, 3)(BulkModulusEquation());
+
+julia> map(f, 1:1:10)
+10-element Array{Float64,1}:
+ 2.0
+ 0.9216086833346415
+ 0.444903691617472
+ 0.2540009203153288
+ 0.16193296566524193
+ 0.11130584492987289
+ 0.08076305569984538
+ 0.06103515625
+ 0.047609811583958425
+ 0.03808959181078831
+```
+"""
+struct BulkModulusEquation{T} <: EquationOfState{T}
+    params::T
+end
+
+# EnergyEquation evaluation
+function (f::EnergyEquation{<:Murnaghan})(v)
+    v0, b0, b′0, e0 = fieldvalues(f.params)
     x, y = b′0 - 1, (v0 / v)^b′0
     return e0 + b0 / b′0 * v * (y / x + 1) - v0 * b0 / x
 end
-function (f::EnergyStyle{<:BirchMurnaghan2nd})(v)
-    v0, b0, e0 = fieldvalues(f.eos)
+function (f::EnergyEquation{<:BirchMurnaghan2nd})(v)
+    v0, b0, e0 = fieldvalues(f.params)
     f = (cbrt(v0 / v)^2 - 1) / 2
     return e0 + 9 / 2 * b0 * v0 * f^2
 end
-function (f::EnergyStyle{<:BirchMurnaghan3rd})(v)
-    v0, b0, b′0, e0 = fieldvalues(f.eos)
+function (f::EnergyEquation{<:BirchMurnaghan3rd})(v)
+    v0, b0, b′0, e0 = fieldvalues(f.params)
     x = cbrt(v0 / v)
     y = x^2 - 1
     return e0 + 9 / 16 * b0 * v0 * y^2 * (6 - 4 * x^2 + b′0 * y)
 end
-function (f::EnergyStyle{<:BirchMurnaghan4th})(v)
-    v0, b0, b′0, b′′0, e0 = fieldvalues(f.eos)
+function (f::EnergyEquation{<:BirchMurnaghan4th})(v)
+    v0, b0, b′0, b′′0, e0 = fieldvalues(f.params)
     f, h = (cbrt(v0 / v)^2 - 1) / 2, b0 * b′′0 + b′0^2
     return e0 + 3 / 8 * v0 * b0 * f^2 * ((9h - 63b′0 + 143) * f^2 + 12f * (b′0 - 4) + 12)
 end
-function (f::EnergyStyle{<:BirchMurnaghan5th})(v)
-    v0, b0, b′0, b′′0, b′′′0, e0 = fieldvalues(f.eos)
+function (f::EnergyEquation{<:BirchMurnaghan5th})(v)
+    v0, b0, b′0, b′′0, b′′′0, e0 = fieldvalues(f.params)
     f = (cbrt(v0 / v)^2 - 1) / 2
     c2 = 9 / 2 * b0 * v0
     c3 = c2 * (b′0 - 4)
@@ -662,24 +662,24 @@ function (f::EnergyStyle{<:BirchMurnaghan5th})(v)
         ) / (180 * c2^2) + b′′′0 * c2^3 / (45 * v0^2)
     return e0 + f^2 * (f * (f * (f * c5 + c4) + c3) + c2)
 end
-function (f::EnergyStyle{<:PoirierTarantola2nd})(v)
-    v0, b0, e0 = fieldvalues(f.eos)
+function (f::EnergyEquation{<:PoirierTarantola2nd})(v)
+    v0, b0, e0 = fieldvalues(f.params)
     return e0 + b0 / 2 * v0 * cbrt(log(v / v0))^2
 end
-function (f::EnergyStyle{<:PoirierTarantola3rd})(v)
-    v0, b0, b′0, e0 = fieldvalues(f.eos)
+function (f::EnergyEquation{<:PoirierTarantola3rd})(v)
+    v0, b0, b′0, e0 = fieldvalues(f.params)
     x = log(v0 / v)
     return e0 + b0 * v0 / 6 * x^2 * ((b′0 - 2) * x + 3)
 end
-function (f::EnergyStyle{<:PoirierTarantola4th})(v)
-    v0, b0, b′0, b′′0, e0 = fieldvalues(f.eos)
+function (f::EnergyEquation{<:PoirierTarantola4th})(v)
+    v0, b0, b′0, b′′0, e0 = fieldvalues(f.params)
     x = cbrt(v / v0)
     xi = log(x)
     h = b0 * b′′0 + b′0^2
     return e0 + b0 / 24v0 * xi^2 * ((h + 3b′0 + 3) * xi^2 + 4 * (b′0 + 2) * xi + 12)
 end
-function (f::EnergyStyle{<:PoirierTarantola5th})(v)
-    v0, b0, b′0, b′′0, b′′′0, e0 = fieldvalues(f.eos)
+function (f::EnergyEquation{<:PoirierTarantola5th})(v)
+    v0, b0, b′0, b′′0, b′′′0, e0 = fieldvalues(f.params)
     f = log(v / v0) / 3
     c = 9 / 2 * b0 * v0
     d = c * (2 - b′0)
@@ -691,75 +691,75 @@ function (f::EnergyStyle{<:PoirierTarantola5th})(v)
         ) / (180 * (c * v0)^2)
     return e0 + f^2 * (f * (f * (f * g + ee) + d) + c)
 end
-function (f::EnergyStyle{<:Vinet})(v)
-    v0, b0, b′0, e0 = fieldvalues(f.eos)
+function (f::EnergyEquation{<:Vinet})(v)
+    v0, b0, b′0, e0 = fieldvalues(f.params)
     x, y = 1 - cbrt(v / v0), 3 / 2 * (b′0 - 1)
     return e0 + 9b0 * v0 / y^2 * (1 + (x * y - 1) * exp(x * y))
 end
-function (f::EnergyStyle{<:AntonSchmidt})(v)
-    v0, β, n, e∞ = fieldvalues(f.eos)
+function (f::EnergyEquation{<:AntonSchmidt})(v)
+    v0, β, n, e∞ = fieldvalues(f.params)
     x, η = v / v0, n + 1
     return e∞ + β * v0 / η * x^η * (log(x) - 1 / η)
 end
-function (f::EnergyStyle{<:PolynomialEOS{N}})(v) where {N}
-    v0, p0, e0 = fieldvalues(f.eos)
+function (f::EnergyEquation{<:PolynomialEOS{N}})(v) where {N}
+    v0, p0, e0 = fieldvalues(f.params)
     return e0 + dot(p0, (v - v0)^n for n in 1:N)  # It cannot be `v0 - v`!
 end # function _evaluate
-# PressureStyle evaluation
-function (f::PressureStyle{<:Murnaghan})(v)
-    v0, b0, b′0 = fieldvalues(f.eos)
+# PressureEquation evaluation
+function (f::PressureEquation{<:Murnaghan})(v)
+    v0, b0, b′0 = fieldvalues(f.params)
     return b0 / b′0 * ((v0 / v)^b′0 - 1)
 end
-function (f::PressureStyle{<:BirchMurnaghan2nd})(v)
-    v0, b0 = fieldvalues(f.eos)
+function (f::PressureEquation{<:BirchMurnaghan2nd})(v)
+    v0, b0 = fieldvalues(f.params)
     f = (cbrt(v0 / v)^2 - 1) / 2
     return 3b0 * f * (1 + 2f)^(5 / 2)
 end
-function (f::PressureStyle{<:BirchMurnaghan3rd})(v)
-    v0, b0, b′0 = fieldvalues(f.eos)
+function (f::PressureEquation{<:BirchMurnaghan3rd})(v)
+    v0, b0, b′0 = fieldvalues(f.params)
     x = cbrt(v0 / v)
     return 3 / 2 * b0 * (x^7 - x^5) * (1 + 3 / 4 * (b′0 - 4) * (x^2 - 1))
 end
-function (f::PressureStyle{<:BirchMurnaghan4th})(v)
-    v0, b0, b′0, b′′0 = fieldvalues(f.eos)
+function (f::PressureEquation{<:BirchMurnaghan4th})(v)
+    v0, b0, b′0, b′′0 = fieldvalues(f.params)
     f, h = (cbrt(v0 / v)^2 - 1) / 2, b0 * b′′0 + b′0^2
     return b0 / 2 * (2f + 1)^(5 / 2) * ((9h - 63b′0 + 143) * f^2 + 9f * (b′0 - 4) + 6)
 end
-function (f::PressureStyle{<:PoirierTarantola2nd})(v)
-    v0, b0 = fieldvalues(f.eos)
+function (f::PressureEquation{<:PoirierTarantola2nd})(v)
+    v0, b0 = fieldvalues(f.params)
     x = cbrt(v / v0)
     return -b0 / x * log(x)
 end
-function (f::PressureStyle{<:PoirierTarantola3rd})(v)
-    v0, b0, b′0 = fieldvalues(f.eos)
+function (f::PressureEquation{<:PoirierTarantola3rd})(v)
+    v0, b0, b′0 = fieldvalues(f.params)
     x = v0 / v
     ξ = log(x)
     return b0 * x * ξ * (1 + (b′0 - 2) / 2 * ξ)
 end
-function (f::PressureStyle{<:PoirierTarantola4th})(v)
-    v0, b0, b′0, b′′0 = fieldvalues(f.eos)
+function (f::PressureEquation{<:PoirierTarantola4th})(v)
+    v0, b0, b′0, b′′0 = fieldvalues(f.params)
     x = cbrt(v / v0)
     xi = log(x)
     h = b0 * b′′0 + b′0^2
     return -b0 * xi / 6 / x * ((h + 3b′0 + 3) * xi^2 + 3xi * (b′0 + 6) + 6)
 end
-function (f::PressureStyle{<:Vinet})(v)
-    v0, b0, b′0 = fieldvalues(f.eos)
+function (f::PressureEquation{<:Vinet})(v)
+    v0, b0, b′0 = fieldvalues(f.params)
     x, y = cbrt(v / v0), 3 // 2 * (b′0 - 1)
     return 3b0 / x^2 * (1 - x) * exp(y * (1 - x))
 end
-function (f::PressureStyle{<:AntonSchmidt})(v)
-    v0, β, n = fieldvalues(f.eos)
+function (f::PressureEquation{<:AntonSchmidt})(v)
+    v0, β, n = fieldvalues(f.params)
     x = v / v0
     return -β * x^n * log(x)
 end
-function (f::PressureStyle{<:BreenanStacey})(v)
-    v0, b0, γ0 = fieldvalues(f.eos)
+function (f::PressureEquation{<:BreenanStacey})(v)
+    v0, b0, γ0 = fieldvalues(f.params)
     x = v0 / v
     return b0 / 2 / γ0 * x^(4 / 3) * (exp(2γ0 * (1 - x)) - 1)
 end
-function (f::PressureStyle{<:Shanker})(v)
-    v0, b0, b′0 = fieldvalues(f.eos)
+function (f::PressureEquation{<:Shanker})(v)
+    v0, b0, b′0 = fieldvalues(f.params)
     x = v / v0
     y = 1 - x
     t = b′0 - 8 / 3
@@ -767,61 +767,61 @@ function (f::PressureStyle{<:Shanker})(v)
            ((1 - 1 / t + 2 / t^2) * exp(t * y - 1) + y * (1 + y - 2 / t) * exp(t * y))
 end
 # Bulk modulus evaluation
-function (f::BulkModulusStyle{<:BirchMurnaghan2nd})(v)
-    v0, b0 = fieldvalues(f.eos)
+function (f::BulkModulusEquation{<:BirchMurnaghan2nd})(v)
+    v0, b0 = fieldvalues(f.params)
     f = (cbrt(v0 / v)^2 - 1) / 2
     return b0 * (7f + 1) * (2f + 1)^(5 / 2)
 end
-function (f::BulkModulusStyle{<:BirchMurnaghan3rd})(v)
-    v0, b0, b′0 = fieldvalues(f.eos)
+function (f::BulkModulusEquation{<:BirchMurnaghan3rd})(v)
+    v0, b0, b′0 = fieldvalues(f.params)
     f = (cbrt(v0 / v)^2 - 1) / 2
     return b0 / 2 * (2f + 1)^(5 / 2) * ((27 * f^2 + 6f) * (b′0 - 4) - 4f + 2)
 end
-function (f::BulkModulusStyle{<:BirchMurnaghan4th})(v)
-    v0, b0, b′0, b′′0 = fieldvalues(f.eos)
+function (f::BulkModulusEquation{<:BirchMurnaghan4th})(v)
+    v0, b0, b′0, b′′0 = fieldvalues(f.params)
     f, h = (cbrt(v0 / v)^2 - 1) / 2, b0 * b′′0 + b′0^2
     return b0 / 6 *
            (2f + 1)^(5 / 2) *
            ((99h - 693b′0 + 1573) * f^3 + (27h - 108b′0 + 105) * f^2 + 6f * (3b′0 - 5) + 6)
 end
-function (f::BulkModulusStyle{<:PoirierTarantola2nd})(v)
-    v0, b0 = fieldvalues(f.eos)
+function (f::BulkModulusEquation{<:PoirierTarantola2nd})(v)
+    v0, b0 = fieldvalues(f.params)
     x = cbrt(v / v0)
     return b0 / x * (1 - log(x))
 end
-function (f::BulkModulusStyle{<:PoirierTarantola3rd})(v)
-    v0, b0, b′0 = fieldvalues(f.eos)
+function (f::BulkModulusEquation{<:PoirierTarantola3rd})(v)
+    v0, b0, b′0 = fieldvalues(f.params)
     x = v / v0
     xi = log(x)
     return -b0 / 2x * (((b′0 - 2) * xi + 2 - 2b′0) * xi + 2)
 end
-function (f::BulkModulusStyle{<:PoirierTarantola4th})(v)
-    v0, b0, b′0, b′′0 = fieldvalues(f.eos)
+function (f::BulkModulusEquation{<:PoirierTarantola4th})(v)
+    v0, b0, b′0, b′′0 = fieldvalues(f.params)
     x = cbrt(v / v0)
     xi = log(x)
     h = b0 * b′′0 + b′0^2
     return -b0 / (6x) *
            ((h + 3b′0 + 3) * xi^3 - 3 * xi^2 * (h + 2b′0 + 1) - 6xi * (b′0 + 1) - 6)
 end
-function (f::BulkModulusStyle{<:Vinet})(v)
-    v0, b0, b′0 = fieldvalues(f.eos)
+function (f::BulkModulusEquation{<:Vinet})(v)
+    v0, b0, b′0 = fieldvalues(f.params)
     x, xi = cbrt(v / v0), 3 / 2 * (b′0 - 1)
     return -b0 / (2 * x^2) * (3x * (x - 1) * (b′0 - 1) + 2 * (x - 2)) * exp(-xi * (x - 1))
 end
-function (f::BulkModulusStyle{<:AntonSchmidt})(v)
-    v0, β, n = fieldvalues(f.eos)
+function (f::BulkModulusEquation{<:AntonSchmidt})(v)
+    v0, β, n = fieldvalues(f.params)
     x = v / v0
     return β * x^n * (1 + n * log(x))
 end
-function (f::BulkModulusStyle{<:Shanker})(v)
-    v0, b0, b′0 = fieldvalues(f.eos)
+function (f::BulkModulusEquation{<:Shanker})(v)
+    v0, b0, b′0 = fieldvalues(f.params)
     x = v / v0
     y = 1 - x
     t = b′0 - 8 / 3
-    return b0 / cbrt(x) * (1 + y + y^2) * exp(t * y) + 4 / 3 * PressureStyle(f.eos)(v)
+    return b0 / cbrt(x) * (1 + y + y^2) * exp(t * y) + 4 / 3 * PressureEquation(f.params)(v)
 end
 
-Base.eltype(::FieldValues{<:EquationOfState{T}}) where {T} = T
-Base.eltype(::Type{<:EquationOfState{T}}) where {T} = T
+Base.eltype(::FieldValues{<:EOSParameters{T}}) where {T} = T
+Base.eltype(::Type{<:EOSParameters{T}}) where {T} = T
 
 end

--- a/src/Find.jl
+++ b/src/Find.jl
@@ -40,7 +40,7 @@ export findvolume
 Find a volume which leads to the given pressure, energy, or bulk modulus based on an `eos`.
 
 # Arguments
-- `eos::EquationOfState`: an equation of state. If it has units, `y` and `x0` must also have.
+- `eos::EOSParameters`: an equation of state. If it has units, `y` and `x0` must also have.
 - `prop::PhysicalProperty`: a `PhysicalProperty` instance.
 - `y`: a pressure, energy, or bulk modulus.
 - `x0`: can be either a range of volumes (`Vector`, `Tuple`, etc.) or just a single volume.

--- a/test/Find.jl
+++ b/test/Find.jl
@@ -76,12 +76,12 @@ using EquationsOfState.Find
     isapprox(
         map(energies) do e
             findvolume(
-                BirchMurnaghan3rd(
+                EnergyStyle(BirchMurnaghan3rd(
                     40.98926572528106 * u"angstrom^3",
                     0.5369258245417454 * u"eV/angstrom^3",
                     4.178644235500821,
                     -10.842803908240892 * u"eV",
-                )(Energy()),
+                )),
                 e,
                 (eps(), 100) .* u"angstrom^3";
                 silent = true,
@@ -95,12 +95,9 @@ end
     pressures = collect(0:20:200) .* u"GPa"
     eos = BirchMurnaghan3rd(167 * u"angstrom^3", 2600 * u"kbar", 4.0)
     volumes = map(pressures) do p
-        findvolume(eos(Pressure()), p, (eps(1.0 * u"bohr^3"), eos.v0 * 1.3); silent = true)
+        findvolume(PressureStyle(eos), p, (eps(1.0 * u"bohr^3"), eos.v0 * 1.3); silent = true)
     end
-    @test isapprox(
-        map(eos(Pressure()), volumes),
-        pressures,
-    )
+    @test isapprox(map(PressureStyle(eos), volumes), pressures)
 end # testset
 
 end # module Find

--- a/test/Find.jl
+++ b/test/Find.jl
@@ -76,7 +76,7 @@ using EquationsOfState.Find
     isapprox(
         map(energies) do e
             findvolume(
-                EnergyStyle(BirchMurnaghan3rd(
+                EnergyEquation(BirchMurnaghan3rd(
                     40.98926572528106 * u"angstrom^3",
                     0.5369258245417454 * u"eV/angstrom^3",
                     4.178644235500821,
@@ -95,9 +95,9 @@ end
     pressures = collect(0:20:200) .* u"GPa"
     eos = BirchMurnaghan3rd(167 * u"angstrom^3", 2600 * u"kbar", 4.0)
     volumes = map(pressures) do p
-        findvolume(PressureStyle(eos), p, (eps(1.0 * u"bohr^3"), eos.v0 * 1.3); silent = true)
+        findvolume(PressureEquation(eos), p, (eps(1.0 * u"bohr^3"), eos.v0 * 1.3); silent = true)
     end
-    @test isapprox(map(PressureStyle(eos), volumes), pressures)
+    @test isapprox(map(PressureEquation(eos), volumes), pressures)
 end # testset
 
 end # module Find

--- a/test/NonlinearFitting.jl
+++ b/test/NonlinearFitting.jl
@@ -6,11 +6,11 @@ using Test
 using Unitful, UnitfulAtomic
 
 using EquationsOfState.Collections
-using EquationsOfState.Collections: EquationOfState
+using EquationsOfState.Collections: EOSParameters
 using EquationsOfState.Fitting: nonlinfit
 
 # Do not export! Only for internal use!
-_isapprox(a::EquationOfState, b::EquationOfState; kwargs...) =
+_isapprox(a::EOSParameters, b::EOSParameters; kwargs...) =
     isapprox(ustrip.(collect(fieldvalues(a))), ustrip.(collect(fieldvalues(b))); kwargs...)
 
 @testset "Test fitting energy with different element types" begin
@@ -22,7 +22,7 @@ _isapprox(a::EquationOfState, b::EquationOfState; kwargs...) =
     )
     @test _isapprox(
         nonlinfit(
-            EnergyStyle(BirchMurnaghan3rd(1, 2, 3.0, 0)),
+            EnergyEquation(BirchMurnaghan3rd(1, 2, 3.0, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -31,7 +31,7 @@ _isapprox(a::EquationOfState, b::EquationOfState; kwargs...) =
     )
     @test _isapprox(
         nonlinfit(
-            EnergyStyle(BirchMurnaghan3rd(1, 2, 3, 0)),
+            EnergyEquation(BirchMurnaghan3rd(1, 2, 3, 0)),
             [1, 2, 3, 4, 5.0],
             [5, 6, 9, 8, 7],
         ),
@@ -40,7 +40,7 @@ _isapprox(a::EquationOfState, b::EquationOfState; kwargs...) =
     )
     @test _isapprox(
         nonlinfit(
-            EnergyStyle(BirchMurnaghan3rd(1, 2, 3.0, 0)),
+            EnergyEquation(BirchMurnaghan3rd(1, 2, 3.0, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7.0],
         ),
@@ -49,7 +49,7 @@ _isapprox(a::EquationOfState, b::EquationOfState; kwargs...) =
     )
     @test _isapprox(
         nonlinfit(
-            EnergyStyle(BirchMurnaghan3rd(1, 2, 3, 0)),
+            EnergyEquation(BirchMurnaghan3rd(1, 2, 3, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -58,7 +58,7 @@ _isapprox(a::EquationOfState, b::EquationOfState; kwargs...) =
     )
     @test _isapprox(
         nonlinfit(
-            EnergyStyle(BirchMurnaghan3rd(big(1), 2, big(3), 0)),
+            EnergyEquation(BirchMurnaghan3rd(big(1), 2, big(3), 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -67,7 +67,7 @@ _isapprox(a::EquationOfState, b::EquationOfState; kwargs...) =
     )
     @test _isapprox(
         nonlinfit(
-            EnergyStyle(BirchMurnaghan3rd(big(1), 2, 3, 0)),
+            EnergyEquation(BirchMurnaghan3rd(big(1), 2, 3, 0)),
             BigFloat[1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -76,7 +76,7 @@ _isapprox(a::EquationOfState, b::EquationOfState; kwargs...) =
     )
     @test _isapprox(
         nonlinfit(
-            EnergyStyle(BirchMurnaghan3rd(big(1.0), 2, 3, 0)),
+            EnergyEquation(BirchMurnaghan3rd(big(1.0), 2, 3, 0)),
             [1, 2, 3, 4, 5],
             BigInt[5, 6, 9, 8, 7],
         ),
@@ -90,7 +90,7 @@ end
         BirchMurnaghan3rd(1.1024687826597717, 29.30861698140365, 12.689089871112746, 0.0)
     @test _isapprox(
         nonlinfit(
-            PressureStyle(BirchMurnaghan3rd(1, 2, 3.0, 0)),
+            PressureEquation(BirchMurnaghan3rd(1, 2, 3.0, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -99,7 +99,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            PressureStyle(BirchMurnaghan3rd(1, 2, 3, 0)),
+            PressureEquation(BirchMurnaghan3rd(1, 2, 3, 0)),
             [1, 2, 3, 4, 5.0],
             [5, 6, 9, 8, 7],
         ),
@@ -108,7 +108,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            PressureStyle(BirchMurnaghan3rd(1, 2, 3.0, 0)),
+            PressureEquation(BirchMurnaghan3rd(1, 2, 3.0, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7.0],
         ),
@@ -117,7 +117,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            PressureStyle(BirchMurnaghan3rd(1, 2, 3, 0)),
+            PressureEquation(BirchMurnaghan3rd(1, 2, 3, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -126,7 +126,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            PressureStyle(BirchMurnaghan3rd(1, 2, big(3), 0)),
+            PressureEquation(BirchMurnaghan3rd(1, 2, big(3), 0)),
             [1, 2, 3, 4, 5],
             BigInt[5, 6, 9, 8, 7],
         ),
@@ -135,7 +135,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            PressureStyle(BirchMurnaghan3rd(1, 2, big(3.0), 0)),
+            PressureEquation(BirchMurnaghan3rd(1, 2, big(3.0), 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -144,7 +144,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            PressureStyle(BirchMurnaghan3rd(1, 2, big(3), 0)),
+            PressureEquation(BirchMurnaghan3rd(1, 2, big(3), 0)),
             [big(1), 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -157,7 +157,7 @@ end
     result = BirchMurnaghan3rd(7.218928431312577, 5.007900469653902, 4.06037725509478, 0.0)
     @test _isapprox(
         nonlinfit(
-            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3.0, 0)),
+            BulkModulusEquation(BirchMurnaghan3rd(1, 2, 3.0, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -166,7 +166,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3, 0)),
+            BulkModulusEquation(BirchMurnaghan3rd(1, 2, 3, 0)),
             [1, 2, 3, 4, 5.0],
             [5, 6, 9, 8, 7],
         ),
@@ -175,7 +175,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3.0, 0)),
+            BulkModulusEquation(BirchMurnaghan3rd(1, 2, 3.0, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7.0],
         ),
@@ -184,7 +184,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3, 0)),
+            BulkModulusEquation(BirchMurnaghan3rd(1, 2, 3, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -193,7 +193,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3, big(0))),
+            BulkModulusEquation(BirchMurnaghan3rd(1, 2, 3, big(0))),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -202,7 +202,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3, big(0))),
+            BulkModulusEquation(BirchMurnaghan3rd(1, 2, 3, big(0))),
             [1, 2, 3, big(4.0), 5],
             [big(5), 6, 9, 8, 7.0],
         ),
@@ -211,7 +211,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3, big(0))),
+            BulkModulusEquation(BirchMurnaghan3rd(1, 2, 3, big(0))),
             [1, 2, 3, 4, 5],
             [big(5), 6, 9, 8, 7.0],
         ),
@@ -284,7 +284,7 @@ end
         -9.73155247952,
     ]
     @test _isapprox(
-        nonlinfit(EnergyStyle(BirchMurnaghan3rd(40, 0.5, 4, 0)), volumes, energies),
+        nonlinfit(EnergyEquation(BirchMurnaghan3rd(40, 0.5, 4, 0)), volumes, energies),
         BirchMurnaghan3rd(
             40.98926572528106,
             0.5369258245417454,
@@ -293,7 +293,7 @@ end
         ),
     )
     @test _isapprox(
-        nonlinfit(EnergyStyle(Murnaghan(41, 0.5, 4, 0)), volumes, energies),
+        nonlinfit(EnergyEquation(Murnaghan(41, 0.5, 4, 0)), volumes, energies),
         Murnaghan(
             41.13757930387086,
             0.5144967693786603,
@@ -302,7 +302,7 @@ end
         ),
     )
     @test _isapprox(
-        nonlinfit(EnergyStyle(PoirierTarantola3rd(41, 0.5, 4, 0)), volumes, energies),
+        nonlinfit(EnergyEquation(PoirierTarantola3rd(41, 0.5, 4, 0)), volumes, energies),
         PoirierTarantola3rd(
             40.86770643373908,
             0.5667729960804602,
@@ -311,7 +311,7 @@ end
         ),
     )
     @test _isapprox(
-        nonlinfit(EnergyStyle(Vinet(41, 0.5, 4, 0)), volumes, energies),
+        nonlinfit(EnergyEquation(Vinet(41, 0.5, 4, 0)), volumes, energies),
         Vinet(
             40.916875663779784,
             0.5493839425156859,
@@ -401,7 +401,7 @@ end
         -1.594410995,
     ]
     fitted_eos =
-        nonlinfit(EnergyStyle(Vinet(23, 0.5, 4, -2)), mp153_volumes, mp153_energies)
+        nonlinfit(EnergyEquation(Vinet(23, 0.5, 4, -2)), mp153_volumes, mp153_energies)
     @test _isapprox(
         fitted_eos,
         Vinet(
@@ -412,7 +412,7 @@ end
         ),
     )
     @test isapprox(
-        map(EnergyStyle(fitted_eos), mp153_volumes),
+        map(EnergyEquation(fitted_eos), mp153_volumes),
         mp153_known_energies_vinet;
         atol = 1e-5,
     )
@@ -489,7 +489,7 @@ end
         -5.118654229,
     ]
     fitted_eos =
-        nonlinfit(EnergyStyle(Vinet(20, 0.5, 4, -5)), mp149_volumes, mp149_energies)
+        nonlinfit(EnergyEquation(Vinet(20, 0.5, 4, -5)), mp149_volumes, mp149_energies)
     @test _isapprox(
         fitted_eos,
         Vinet(
@@ -500,7 +500,7 @@ end
         ),
     )
     @test isapprox(
-        map(EnergyStyle(fitted_eos), mp149_volumes),
+        map(EnergyEquation(fitted_eos), mp149_volumes),
         mp149_known_energies_vinet;
         atol = 1e-5,
     )
@@ -576,7 +576,7 @@ end
         -7.892053535,
         -7.897414664,
     ]
-    fitted_eos = nonlinfit(EnergyStyle(Vinet(17, 0.5, 4, -7)), mp72_volumes, mp72_energies)
+    fitted_eos = nonlinfit(EnergyEquation(Vinet(17, 0.5, 4, -7)), mp72_volumes, mp72_energies)
     @test _isapprox(
         fitted_eos,
         Vinet(
@@ -587,7 +587,7 @@ end
         ),
     )
     @test isapprox(
-        map(EnergyStyle(fitted_eos), mp72_volumes),
+        map(EnergyEquation(fitted_eos), mp72_volumes),
         mp72_known_energies_vinet;
         atol = 1e-5,
     )
@@ -603,20 +603,20 @@ end
         energies = data[:, 2]  # unit: Rydberg
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L117-L122
         @test _isapprox(
-            nonlinfit(EnergyStyle(Murnaghan(224, 0.006, 4, -323)), volumes, energies),
+            nonlinfit(EnergyEquation(Murnaghan(224, 0.006, 4, -323)), volumes, energies),
             Murnaghan(224.501825, 0.00060479524074699499, 3.723835, -323.417686);
             atol = 1e-5,
         )
         # No reference data, I run on my computer.
         @test _isapprox(
-            nonlinfit(EnergyStyle(BirchMurnaghan2nd(224, 0.0006, -323)), volumes, energies),
+            nonlinfit(EnergyEquation(BirchMurnaghan2nd(224, 0.0006, -323)), volumes, energies),
             BirchMurnaghan2nd(223.7192539523166, 0.0006268341030294977, -323.4177121144877);
             atol = 1e-3,
         )
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L15-L20
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(BirchMurnaghan3rd(224, 0.0006, 4, -323)),
+                EnergyEquation(BirchMurnaghan3rd(224, 0.0006, 4, -323)),
                 volumes,
                 energies,
             ),
@@ -625,7 +625,7 @@ end
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L30-L36
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(BirchMurnaghan4th(224, 0.0006, 4, -5460, -323)),  # bohr^3, Ry/bohr^3, 1, bohr^3/Ry, Ry
+                EnergyEquation(BirchMurnaghan4th(224, 0.0006, 4, -5460, -323)),  # bohr^3, Ry/bohr^3, 1, bohr^3/Ry, Ry
                 volumes,
                 energies,
             ),
@@ -641,7 +641,7 @@ end
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L98-L105
         # @test _isapprox(
         #     nonlinfit(
-        # EnergyStyle(        #         BirchMurnaghan5th(224.445371, 0.0006, 4, -5500, 3.884535907971559e7, -323)),
+        # EnergyEquation(        #         BirchMurnaghan5th(224.445371, 0.0006, 4, -5500, 3.884535907971559e7, -323)),
         #         volumes,
         #         energies,
         #     ),
@@ -657,7 +657,7 @@ end
         # )  # FIXME: result is wrong
         # # No reference data, I run on my computer.
         # @test _isapprox(
-        # EnergyStyle(        #     nonlinfit(Vinet(224, 0.0006, 4, -323)), volumes, energies),
+        # EnergyEquation(        #     nonlinfit(Vinet(224, 0.0006, 4, -323)), volumes, energies),
         #     Vinet(
         #         224.45278665796354,
         #         0.0006313500637481759,
@@ -667,14 +667,14 @@ end
         # )
         # # FIXME: The result is rather wrong
         # @test _isapprox(
-        # EnergyStyle(        #     nonlinfit(PoirierTarantola3rd(224, 0.0006, 4, -323)), volumes, energies),
+        # EnergyEquation(        #     nonlinfit(PoirierTarantola3rd(224, 0.0006, 4, -323)), volumes, energies),
         #     PoirierTarantola3rd(224.509208, 0.000635892264159838, 3.690448, -323.41773);
         #     atol = 1e-5,
         # )
         # # FIXME: This cannot go through
         # @test _isapprox(
         #     nonlinfit(
-        # EnergyStyle(        #         PoirierTarantola4th(220, 0.0006, 3.7, -5500, -323)),
+        # EnergyEquation(        #         PoirierTarantola4th(220, 0.0006, 3.7, -5500, -323)),
         #         volumes,
         #         energies,
         #     ),
@@ -689,7 +689,7 @@ end
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L98-L105
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(PoirierTarantola5th(224.445371, 0.0006, 3.8, -5500, 6e7, -323)),
+                EnergyEquation(PoirierTarantola5th(224.445371, 0.0006, 3.8, -5500, 6e7, -323)),
                 volumes,
                 energies,
             ),
@@ -711,7 +711,7 @@ end
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L117-L122
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(Murnaghan(
+                EnergyEquation(Murnaghan(
                     224.445371 * u"bohr^3",
                     9.164446 * u"GPa",
                     3.752432,
@@ -731,7 +731,7 @@ end
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L15-L20
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(BirchMurnaghan3rd(
+                EnergyEquation(BirchMurnaghan3rd(
                     224.445371 * u"bohr^3",
                     9.164446 * u"GPa",
                     3.752432,
@@ -749,7 +749,7 @@ end
         )
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(BirchMurnaghan4th(
+                EnergyEquation(BirchMurnaghan4th(
                     224.445371 * u"bohr^3",
                     9.164446 * u"GPa",
                     3.752432,
@@ -771,7 +771,7 @@ end
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L98-L105
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(BirchMurnaghan5th(
+                EnergyEquation(BirchMurnaghan5th(
                     224.445371 * u"bohr^3",
                     9.164446 * u"GPa",
                     3.752432,
@@ -794,7 +794,7 @@ end
         )
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(PoirierTarantola3rd(
+                EnergyEquation(PoirierTarantola3rd(
                     224.445371 * u"bohr^3",
                     9.164446 * u"GPa",
                     3.7,
@@ -821,7 +821,7 @@ end
         volumes = data[:, 1]  # unit: bohr^3
         energies = data[:, 2]  # unit: Rydberg
         @test _isapprox(
-            nonlinfit(EnergyStyle(Murnaghan(224, 0.0006, 4, -323)), volumes, energies),
+            nonlinfit(EnergyEquation(Murnaghan(224, 0.0006, 4, -323)), volumes, energies),
             Murnaghan(
                 435.05782299050884,
                 0.00028297159355249787,
@@ -831,7 +831,7 @@ end
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(EnergyStyle(BirchMurnaghan2nd(224, 0.0006, -323)), volumes, energies),
+            nonlinfit(EnergyEquation(BirchMurnaghan2nd(224, 0.0006, -323)), volumes, energies),
             BirchMurnaghan2nd(
                 430.10027687726716,
                 0.000302451215462375,
@@ -841,7 +841,7 @@ end
         )
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(BirchMurnaghan3rd(224, 0.0006, 4, -323)),
+                EnergyEquation(BirchMurnaghan3rd(224, 0.0006, 4, -323)),
                 volumes,
                 energies,
             ),
@@ -855,7 +855,7 @@ end
         )
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(BirchMurnaghan4th(432, 0.0003, 3.8, -11773, -1201)),
+                EnergyEquation(BirchMurnaghan4th(432, 0.0003, 3.8, -11773, -1201)),
                 volumes,
                 energies,
             ),
@@ -869,7 +869,7 @@ end
             rtol = 1e-5,
         )
         @test _isapprox(
-            nonlinfit(EnergyStyle(Vinet(432, 0.0003, 3.8, -1201)), volumes, energies),
+            nonlinfit(EnergyEquation(Vinet(432, 0.0003, 3.8, -1201)), volumes, energies),
             Vinet(
                 432.04609865398015,
                 0.0003137631070690569,
@@ -884,7 +884,7 @@ end
         volumes = data[:, 1] .* u"bohr^3"
         energies = data[:, 2] .* u"Ry"
         fitted_eos = nonlinfit(
-            EnergyStyle(BirchMurnaghan3rd(
+            EnergyEquation(BirchMurnaghan3rd(
                 224 * u"bohr^3",
                 0.0006 * u"Ry/bohr^3",
                 4,
@@ -904,7 +904,7 @@ end
         )
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(BirchMurnaghan3rd(
+                EnergyEquation(BirchMurnaghan3rd(
                     224 * u"bohr^3",
                     10 * u"GPa",
                     3.75,
@@ -937,7 +937,7 @@ end
                 -7.410112 * u"hartree",
             ),
             nonlinfit(
-                EnergyStyle(BirchMurnaghan3rd(
+                EnergyEquation(BirchMurnaghan3rd(
                     128.319495 * u"bohr^3",
                     15.070313 * u"GPa",
                     3.357205,
@@ -957,7 +957,7 @@ end
                 -7.410326 * u"hartree",
             ),
             nonlinfit(
-                EnergyStyle(BirchMurnaghan4th(
+                EnergyEquation(BirchMurnaghan4th(
                     128.319495 * u"bohr^3",
                     15.070313 * u"GPa",
                     3.357205,
@@ -979,7 +979,7 @@ end # testset
         volumes = data[:, 1]  # unit: bohr^3
         energies = data[:, 2]  # unit: Rydberg
         @test _isapprox(
-            nonlinfit(EnergyStyle(Murnaghan(110, 0.01, 4, -34)), volumes, energies),
+            nonlinfit(EnergyEquation(Murnaghan(110, 0.01, 4, -34)), volumes, energies),
             Murnaghan(
                 124.88539638285143,
                 0.012047999390789954,
@@ -989,12 +989,12 @@ end # testset
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(EnergyStyle(BirchMurnaghan2nd(124, 0.012, -34)), volumes, energies),
+            nonlinfit(EnergyEquation(BirchMurnaghan2nd(124, 0.012, -34)), volumes, energies),
             BirchMurnaghan2nd(124.60346122403192, 0.0119478059177848, -34.344520503316495);
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(EnergyStyle(BirchMurnaghan3rd(110, 0.01, 4, -34)), volumes, energies),
+            nonlinfit(EnergyEquation(BirchMurnaghan3rd(110, 0.01, 4, -34)), volumes, energies),
             BirchMurnaghan3rd(
                 124.82366127014902,
                 0.011559181270548115,
@@ -1005,7 +1005,7 @@ end # testset
         )
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(BirchMurnaghan4th(124, 0.01, 4, -5300, -34)),
+                EnergyEquation(BirchMurnaghan4th(124, 0.01, 4, -5300, -34)),
                 volumes,
                 energies,
             ),
@@ -1019,7 +1019,7 @@ end # testset
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(EnergyStyle(Vinet(124, 0.01, 4, -34)), volumes, energies),
+            nonlinfit(EnergyEquation(Vinet(124, 0.01, 4, -34)), volumes, energies),
             Vinet(
                 124.78343088049905,
                 0.011244915521226076,
@@ -1034,7 +1034,7 @@ end # testset
         volumes = data[:, 1] .* u"angstrom^3"
         energies = data[:, 2] .* u"Ry"
         fitted_eos = nonlinfit(
-            EnergyStyle(BirchMurnaghan3rd(
+            EnergyEquation(BirchMurnaghan3rd(
                 110 * u"angstrom^3",
                 0.01 * u"Ry/angstrom^3",
                 4,
@@ -1054,7 +1054,7 @@ end # testset
         )
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(BirchMurnaghan3rd(
+                EnergyEquation(BirchMurnaghan3rd(
                     124 * u"angstrom^3",
                     20 * u"GPa",
                     4,
@@ -1080,7 +1080,7 @@ end
         volumes = data[:, 1]  # unit: bohr^3
         energies = data[:, 2]  # unit: Rydberg
         @test _isapprox(
-            nonlinfit(EnergyStyle(Murnaghan(132, 0.01, 3.68, -14)), volumes, energies),
+            nonlinfit(EnergyEquation(Murnaghan(132, 0.01, 3.68, -14)), volumes, energies),
             Murnaghan(
                 132.9174710492377,
                 0.000997071972650323,
@@ -1090,12 +1090,12 @@ end
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(EnergyStyle(BirchMurnaghan2nd(132, 0.01, -14)), volumes, energies),
+            nonlinfit(EnergyEquation(BirchMurnaghan2nd(132, 0.01, -14)), volumes, energies),
             BirchMurnaghan2nd(130.7191505712864, 0.000706623449967504, -14.817402887854884);
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(EnergyStyle(BirchMurnaghan3rd(128, 0.03, 4, -14)), volumes, energies),
+            nonlinfit(EnergyEquation(BirchMurnaghan3rd(128, 0.03, 4, -14)), volumes, energies),
             BirchMurnaghan3rd(
                 126.49515516259525,
                 0.0010084167615290376,
@@ -1106,7 +1106,7 @@ end
         )
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(BirchMurnaghan4th(128, 0.03, 4, -320, -14)),
+                EnergyEquation(BirchMurnaghan4th(128, 0.03, 4, -320, -14)),
                 volumes,
                 energies,
             ),
@@ -1120,7 +1120,7 @@ end
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(EnergyStyle(Vinet(128, 0.03, 4, -14)), volumes, energies),
+            nonlinfit(EnergyEquation(Vinet(128, 0.03, 4, -14)), volumes, energies),
             Vinet(
                 124.71725873851614,
                 0.001064866793589798,
@@ -1135,7 +1135,7 @@ end
         volumes = data[:, 1] .* u"bohr^3"
         energies = data[:, 2] .* u"Ry"
         fitted_eos = nonlinfit(
-            EnergyStyle(BirchMurnaghan3rd(
+            EnergyEquation(BirchMurnaghan3rd(
                 128 * u"bohr^3",
                 0.03 * u"Ry/bohr^3",
                 4,
@@ -1155,7 +1155,7 @@ end
         )
         @test _isapprox(
             nonlinfit(
-                EnergyStyle(BirchMurnaghan3rd(
+                EnergyEquation(BirchMurnaghan3rd(
                     128 * u"bohr^3",
                     44 * u"GPa",
                     4,

--- a/test/NonlinearFitting.jl
+++ b/test/NonlinearFitting.jl
@@ -21,18 +21,26 @@ _isapprox(a::EquationOfState, b::EquationOfState; kwargs...) =
         big(-40.31992619868024),
     )
     @test _isapprox(
-        nonlinfit(BirchMurnaghan3rd(1, 2, 3.0, 0)(Energy()), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
-        result;
-        atol = 1e-5,
-    )
-    @test _isapprox(
-        nonlinfit(BirchMurnaghan3rd(1, 2, 3, 0)(Energy()), [1, 2, 3, 4, 5.0], [5, 6, 9, 8, 7]),
+        nonlinfit(
+            EnergyStyle(BirchMurnaghan3rd(1, 2, 3.0, 0)),
+            [1, 2, 3, 4, 5],
+            [5, 6, 9, 8, 7],
+        ),
         result;
         atol = 1e-5,
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, 3.0, 0)(Energy()),
+            EnergyStyle(BirchMurnaghan3rd(1, 2, 3, 0)),
+            [1, 2, 3, 4, 5.0],
+            [5, 6, 9, 8, 7],
+        ),
+        result;
+        atol = 1e-5,
+    )
+    @test _isapprox(
+        nonlinfit(
+            EnergyStyle(BirchMurnaghan3rd(1, 2, 3.0, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7.0],
         ),
@@ -40,13 +48,17 @@ _isapprox(a::EquationOfState, b::EquationOfState; kwargs...) =
         atol = 1e-5,
     )
     @test _isapprox(
-        nonlinfit(BirchMurnaghan3rd(1, 2, 3, 0)(Energy()), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
+        nonlinfit(
+            EnergyStyle(BirchMurnaghan3rd(1, 2, 3, 0)),
+            [1, 2, 3, 4, 5],
+            [5, 6, 9, 8, 7],
+        ),
         result;
         atol = 1e-5,
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(big(1), 2, big(3), 0)(Energy()),
+            EnergyStyle(BirchMurnaghan3rd(big(1), 2, big(3), 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -55,7 +67,7 @@ _isapprox(a::EquationOfState, b::EquationOfState; kwargs...) =
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(big(1), 2, 3, 0)(Energy()),
+            EnergyStyle(BirchMurnaghan3rd(big(1), 2, 3, 0)),
             BigFloat[1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -64,7 +76,7 @@ _isapprox(a::EquationOfState, b::EquationOfState; kwargs...) =
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(big(1.0), 2, 3, 0)(Energy()),
+            EnergyStyle(BirchMurnaghan3rd(big(1.0), 2, 3, 0)),
             [1, 2, 3, 4, 5],
             BigInt[5, 6, 9, 8, 7],
         ),
@@ -78,7 +90,7 @@ end
         BirchMurnaghan3rd(1.1024687826597717, 29.30861698140365, 12.689089871112746, 0.0)
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, 3.0, 0)(Pressure()),
+            PressureStyle(BirchMurnaghan3rd(1, 2, 3.0, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -87,7 +99,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, 3, 0)(Pressure()),
+            PressureStyle(BirchMurnaghan3rd(1, 2, 3, 0)),
             [1, 2, 3, 4, 5.0],
             [5, 6, 9, 8, 7],
         ),
@@ -96,7 +108,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, 3.0, 0)(Pressure()),
+            PressureStyle(BirchMurnaghan3rd(1, 2, 3.0, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7.0],
         ),
@@ -104,22 +116,8 @@ end
         atol = 1e-6,
     )
     @test _isapprox(
-        nonlinfit(BirchMurnaghan3rd(1, 2, 3, 0)(Pressure()), [1, 2, 3, 4, 5], [5, 6, 9, 8, 7]),
-        result;
-        atol = 1e-6,
-    )
-    @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, big(3), 0)(Pressure()),
-            [1, 2, 3, 4, 5],
-            BigInt[5, 6, 9, 8, 7],
-        ),
-        result;
-        atol = 1e-6,
-    )
-    @test _isapprox(
-        nonlinfit(
-            BirchMurnaghan3rd(1, 2, big(3.0), 0)(Pressure()),
+            PressureStyle(BirchMurnaghan3rd(1, 2, 3, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -128,7 +126,25 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, big(3), 0)(Pressure()),
+            PressureStyle(BirchMurnaghan3rd(1, 2, big(3), 0)),
+            [1, 2, 3, 4, 5],
+            BigInt[5, 6, 9, 8, 7],
+        ),
+        result;
+        atol = 1e-6,
+    )
+    @test _isapprox(
+        nonlinfit(
+            PressureStyle(BirchMurnaghan3rd(1, 2, big(3.0), 0)),
+            [1, 2, 3, 4, 5],
+            [5, 6, 9, 8, 7],
+        ),
+        result;
+        atol = 1e-6,
+    )
+    @test _isapprox(
+        nonlinfit(
+            PressureStyle(BirchMurnaghan3rd(1, 2, big(3), 0)),
             [big(1), 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -141,7 +157,7 @@ end
     result = BirchMurnaghan3rd(7.218928431312577, 5.007900469653902, 4.06037725509478, 0.0)
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, 3.0, 0)(BulkModulus()),
+            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3.0, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -150,7 +166,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, 3, 0)(BulkModulus()),
+            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3, 0)),
             [1, 2, 3, 4, 5.0],
             [5, 6, 9, 8, 7],
         ),
@@ -159,7 +175,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, 3.0, 0)(BulkModulus()),
+            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3.0, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7.0],
         ),
@@ -168,7 +184,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, 3, 0)(BulkModulus()),
+            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3, 0)),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -177,7 +193,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, 3, big(0))(BulkModulus()),
+            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3, big(0))),
             [1, 2, 3, 4, 5],
             [5, 6, 9, 8, 7],
         ),
@@ -186,7 +202,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, 3, big(0))(BulkModulus()),
+            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3, big(0))),
             [1, 2, 3, big(4.0), 5],
             [big(5), 6, 9, 8, 7.0],
         ),
@@ -195,7 +211,7 @@ end
     )
     @test _isapprox(
         nonlinfit(
-            BirchMurnaghan3rd(1, 2, 3, big(0))(BulkModulus()),
+            BulkModulusStyle(BirchMurnaghan3rd(1, 2, 3, big(0))),
             [1, 2, 3, 4, 5],
             [big(5), 6, 9, 8, 7.0],
         ),
@@ -268,7 +284,7 @@ end
         -9.73155247952,
     ]
     @test _isapprox(
-        nonlinfit(BirchMurnaghan3rd(40, 0.5, 4, 0)(Energy()), volumes, energies),
+        nonlinfit(EnergyStyle(BirchMurnaghan3rd(40, 0.5, 4, 0)), volumes, energies),
         BirchMurnaghan3rd(
             40.98926572528106,
             0.5369258245417454,
@@ -277,7 +293,7 @@ end
         ),
     )
     @test _isapprox(
-        nonlinfit(Murnaghan(41, 0.5, 4, 0)(Energy()), volumes, energies),
+        nonlinfit(EnergyStyle(Murnaghan(41, 0.5, 4, 0)), volumes, energies),
         Murnaghan(
             41.13757930387086,
             0.5144967693786603,
@@ -286,7 +302,7 @@ end
         ),
     )
     @test _isapprox(
-        nonlinfit(PoirierTarantola3rd(41, 0.5, 4, 0)(Energy()), volumes, energies),
+        nonlinfit(EnergyStyle(PoirierTarantola3rd(41, 0.5, 4, 0)), volumes, energies),
         PoirierTarantola3rd(
             40.86770643373908,
             0.5667729960804602,
@@ -295,7 +311,7 @@ end
         ),
     )
     @test _isapprox(
-        nonlinfit(Vinet(41, 0.5, 4, 0)(Energy()), volumes, energies),
+        nonlinfit(EnergyStyle(Vinet(41, 0.5, 4, 0)), volumes, energies),
         Vinet(
             40.916875663779784,
             0.5493839425156859,
@@ -384,7 +400,8 @@ end
         -1.592547954,
         -1.594410995,
     ]
-    fitted_eos = nonlinfit(Vinet(23, 0.5, 4, -2)(Energy()), mp153_volumes, mp153_energies)
+    fitted_eos =
+        nonlinfit(EnergyStyle(Vinet(23, 0.5, 4, -2)), mp153_volumes, mp153_energies)
     @test _isapprox(
         fitted_eos,
         Vinet(
@@ -395,7 +412,7 @@ end
         ),
     )
     @test isapprox(
-        map(fitted_eos(Energy()), mp153_volumes),
+        map(EnergyStyle(fitted_eos), mp153_volumes),
         mp153_known_energies_vinet;
         atol = 1e-5,
     )
@@ -471,7 +488,8 @@ end
         -5.058639193,
         -5.118654229,
     ]
-    fitted_eos = nonlinfit(Vinet(20, 0.5, 4, -5)(Energy()), mp149_volumes, mp149_energies)
+    fitted_eos =
+        nonlinfit(EnergyStyle(Vinet(20, 0.5, 4, -5)), mp149_volumes, mp149_energies)
     @test _isapprox(
         fitted_eos,
         Vinet(
@@ -482,7 +500,7 @@ end
         ),
     )
     @test isapprox(
-        map(fitted_eos(Energy()), mp149_volumes),
+        map(EnergyStyle(fitted_eos), mp149_volumes),
         mp149_known_energies_vinet;
         atol = 1e-5,
     )
@@ -558,7 +576,7 @@ end
         -7.892053535,
         -7.897414664,
     ]
-    fitted_eos = nonlinfit(Vinet(17, 0.5, 4, -7)(Energy()), mp72_volumes, mp72_energies)
+    fitted_eos = nonlinfit(EnergyStyle(Vinet(17, 0.5, 4, -7)), mp72_volumes, mp72_energies)
     @test _isapprox(
         fitted_eos,
         Vinet(
@@ -569,7 +587,7 @@ end
         ),
     )
     @test isapprox(
-        map(fitted_eos(Energy()), mp72_volumes),
+        map(EnergyStyle(fitted_eos), mp72_volumes),
         mp72_known_energies_vinet;
         atol = 1e-5,
     )
@@ -585,25 +603,29 @@ end
         energies = data[:, 2]  # unit: Rydberg
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L117-L122
         @test _isapprox(
-            nonlinfit(Murnaghan(224, 0.006, 4, -323)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(Murnaghan(224, 0.006, 4, -323)), volumes, energies),
             Murnaghan(224.501825, 0.00060479524074699499, 3.723835, -323.417686);
             atol = 1e-5,
         )
         # No reference data, I run on my computer.
         @test _isapprox(
-            nonlinfit(BirchMurnaghan2nd(224, 0.0006, -323)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(BirchMurnaghan2nd(224, 0.0006, -323)), volumes, energies),
             BirchMurnaghan2nd(223.7192539523166, 0.0006268341030294977, -323.4177121144877);
             atol = 1e-3,
         )
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L15-L20
         @test _isapprox(
-            nonlinfit(BirchMurnaghan3rd(224, 0.0006, 4, -323)(Energy()), volumes, energies),
+            nonlinfit(
+                EnergyStyle(BirchMurnaghan3rd(224, 0.0006, 4, -323)),
+                volumes,
+                energies,
+            ),
             BirchMurnaghan3rd(224.444565, 0.00062506191050572675, 3.740369, -323.417714),
         )
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L30-L36
         @test _isapprox(
             nonlinfit(
-                BirchMurnaghan4th(224, 0.0006, 4, -5460, -323)(Energy()),  # bohr^3, Ry/bohr^3, 1, bohr^3/Ry, Ry
+                EnergyStyle(BirchMurnaghan4th(224, 0.0006, 4, -5460, -323)),  # bohr^3, Ry/bohr^3, 1, bohr^3/Ry, Ry
                 volumes,
                 energies,
             ),
@@ -619,7 +641,7 @@ end
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L98-L105
         # @test _isapprox(
         #     nonlinfit(
-        #         BirchMurnaghan5th(224.445371, 0.0006, 4, -5500, 3.884535907971559e7, -323)(Energy()),
+        # EnergyStyle(        #         BirchMurnaghan5th(224.445371, 0.0006, 4, -5500, 3.884535907971559e7, -323)),
         #         volumes,
         #         energies,
         #     ),
@@ -635,7 +657,7 @@ end
         # )  # FIXME: result is wrong
         # # No reference data, I run on my computer.
         # @test _isapprox(
-        #     nonlinfit(Vinet(224, 0.0006, 4, -323)(Energy()), volumes, energies),
+        # EnergyStyle(        #     nonlinfit(Vinet(224, 0.0006, 4, -323)), volumes, energies),
         #     Vinet(
         #         224.45278665796354,
         #         0.0006313500637481759,
@@ -645,14 +667,14 @@ end
         # )
         # # FIXME: The result is rather wrong
         # @test _isapprox(
-        #     nonlinfit(PoirierTarantola3rd(224, 0.0006, 4, -323)(Energy()), volumes, energies),
+        # EnergyStyle(        #     nonlinfit(PoirierTarantola3rd(224, 0.0006, 4, -323)), volumes, energies),
         #     PoirierTarantola3rd(224.509208, 0.000635892264159838, 3.690448, -323.41773);
         #     atol = 1e-5,
         # )
         # # FIXME: This cannot go through
         # @test _isapprox(
         #     nonlinfit(
-        #         PoirierTarantola4th(220, 0.0006, 3.7, -5500, -323)(Energy()),
+        # EnergyStyle(        #         PoirierTarantola4th(220, 0.0006, 3.7, -5500, -323)),
         #         volumes,
         #         energies,
         #     ),
@@ -667,7 +689,7 @@ end
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L98-L105
         @test _isapprox(
             nonlinfit(
-                PoirierTarantola5th(224.445371, 0.0006, 3.8, -5500, 6e7, -323)(Energy()),
+                EnergyStyle(PoirierTarantola5th(224.445371, 0.0006, 3.8, -5500, 6e7, -323)),
                 volumes,
                 energies,
             ),
@@ -689,12 +711,12 @@ end
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L117-L122
         @test _isapprox(
             nonlinfit(
-                Murnaghan(
+                EnergyStyle(Murnaghan(
                     224.445371 * u"bohr^3",
                     9.164446 * u"GPa",
                     3.752432,
                     -161.708856 * u"hartree",
-                )(Energy()),
+                )),
                 volumes,
                 energies,
             ),
@@ -709,12 +731,12 @@ end
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L15-L20
         @test _isapprox(
             nonlinfit(
-                BirchMurnaghan3rd(
+                EnergyStyle(BirchMurnaghan3rd(
                     224.445371 * u"bohr^3",
                     9.164446 * u"GPa",
                     3.752432,
                     -161.708856 * u"hartree",
-                )(Energy()),
+                )),
                 volumes,
                 energies,
             ),
@@ -727,13 +749,13 @@ end
         )
         @test _isapprox(
             nonlinfit(
-                BirchMurnaghan4th(
+                EnergyStyle(BirchMurnaghan4th(
                     224.445371 * u"bohr^3",
                     9.164446 * u"GPa",
                     3.752432,
                     -0.371174 * u"1/GPa",
                     -161.708856 * u"hartree",
-                )(Energy()),
+                )),
                 volumes,
                 energies,
             ),
@@ -749,14 +771,14 @@ end
         # See https://github.com/aoterodelaroza/asturfit/blob/0909b1468e44d691b0c7a44a5b583d170dd248ff/test/test03.out#L98-L105
         @test _isapprox(
             nonlinfit(
-                BirchMurnaghan5th(
+                EnergyStyle(BirchMurnaghan5th(
                     224.445371 * u"bohr^3",
                     9.164446 * u"GPa",
                     3.752432,
                     -0.371174 * u"1/GPa",
                     0.179508 * u"1/GPa^2",
                     -161.708856 * u"hartree",
-                )(Energy()),
+                )),
                 volumes,
                 energies,
             ),
@@ -772,12 +794,12 @@ end
         )
         @test _isapprox(
             nonlinfit(
-                PoirierTarantola3rd(
+                EnergyStyle(PoirierTarantola3rd(
                     224.445371 * u"bohr^3",
                     9.164446 * u"GPa",
                     3.7,
                     -161.708856 * u"hartree",
-                )(Energy()),
+                )),
                 volumes,
                 energies,
             ),
@@ -799,7 +821,7 @@ end
         volumes = data[:, 1]  # unit: bohr^3
         energies = data[:, 2]  # unit: Rydberg
         @test _isapprox(
-            nonlinfit(Murnaghan(224, 0.0006, 4, -323)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(Murnaghan(224, 0.0006, 4, -323)), volumes, energies),
             Murnaghan(
                 435.05782299050884,
                 0.00028297159355249787,
@@ -809,7 +831,7 @@ end
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(BirchMurnaghan2nd(224, 0.0006, -323)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(BirchMurnaghan2nd(224, 0.0006, -323)), volumes, energies),
             BirchMurnaghan2nd(
                 430.10027687726716,
                 0.000302451215462375,
@@ -818,7 +840,11 @@ end
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(BirchMurnaghan3rd(224, 0.0006, 4, -323)(Energy()), volumes, energies),
+            nonlinfit(
+                EnergyStyle(BirchMurnaghan3rd(224, 0.0006, 4, -323)),
+                volumes,
+                energies,
+            ),
             BirchMurnaghan3rd(
                 432.67139080209046,
                 0.00030508544859901674,
@@ -829,7 +855,7 @@ end
         )
         @test _isapprox(
             nonlinfit(
-                BirchMurnaghan4th(432, 0.0003, 3.8, -11773, -1201)(Energy()),
+                EnergyStyle(BirchMurnaghan4th(432, 0.0003, 3.8, -11773, -1201)),
                 volumes,
                 energies,
             ),
@@ -843,7 +869,7 @@ end
             rtol = 1e-5,
         )
         @test _isapprox(
-            nonlinfit(Vinet(432, 0.0003, 3.8, -1201)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(Vinet(432, 0.0003, 3.8, -1201)), volumes, energies),
             Vinet(
                 432.04609865398015,
                 0.0003137631070690569,
@@ -858,7 +884,12 @@ end
         volumes = data[:, 1] .* u"bohr^3"
         energies = data[:, 2] .* u"Ry"
         fitted_eos = nonlinfit(
-            BirchMurnaghan3rd(224 * u"bohr^3", 0.0006 * u"Ry/bohr^3", 4, -323 * u"Ry")(Energy()),
+            EnergyStyle(BirchMurnaghan3rd(
+                224 * u"bohr^3",
+                0.0006 * u"Ry/bohr^3",
+                4,
+                -323 * u"Ry",
+            )),
             volumes,
             energies,
         )
@@ -873,7 +904,12 @@ end
         )
         @test _isapprox(
             nonlinfit(
-                BirchMurnaghan3rd(224 * u"bohr^3", 10 * u"GPa", 3.75, -161 * u"hartree")(Energy()),
+                EnergyStyle(BirchMurnaghan3rd(
+                    224 * u"bohr^3",
+                    10 * u"GPa",
+                    3.75,
+                    -161 * u"hartree",
+                )),
                 volumes,
                 energies,
             ),
@@ -901,12 +937,12 @@ end
                 -7.410112 * u"hartree",
             ),
             nonlinfit(
-                BirchMurnaghan3rd(
+                EnergyStyle(BirchMurnaghan3rd(
                     128.319495 * u"bohr^3",
                     15.070313 * u"GPa",
                     3.357205,
                     -7.410318 * u"hartree",
-                )(Energy()),
+                )),
                 volumes,
                 energies,
             );
@@ -921,13 +957,13 @@ end
                 -7.410326 * u"hartree",
             ),
             nonlinfit(
-                BirchMurnaghan4th(
+                EnergyStyle(BirchMurnaghan4th(
                     128.319495 * u"bohr^3",
                     15.070313 * u"GPa",
                     3.357205,
                     -0.178271 * u"1/GPa",
                     -7.410318 * u"hartree",
-                )(Energy()),
+                )),
                 volumes,
                 energies,
             );
@@ -943,7 +979,7 @@ end # testset
         volumes = data[:, 1]  # unit: bohr^3
         energies = data[:, 2]  # unit: Rydberg
         @test _isapprox(
-            nonlinfit(Murnaghan(110, 0.01, 4, -34)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(Murnaghan(110, 0.01, 4, -34)), volumes, energies),
             Murnaghan(
                 124.88539638285143,
                 0.012047999390789954,
@@ -953,12 +989,12 @@ end # testset
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(BirchMurnaghan2nd(124, 0.012, -34)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(BirchMurnaghan2nd(124, 0.012, -34)), volumes, energies),
             BirchMurnaghan2nd(124.60346122403192, 0.0119478059177848, -34.344520503316495);
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(BirchMurnaghan3rd(110, 0.01, 4, -34)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(BirchMurnaghan3rd(110, 0.01, 4, -34)), volumes, energies),
             BirchMurnaghan3rd(
                 124.82366127014902,
                 0.011559181270548115,
@@ -969,7 +1005,7 @@ end # testset
         )
         @test _isapprox(
             nonlinfit(
-                BirchMurnaghan4th(124, 0.01, 4, -5300, -34)(Energy()),
+                EnergyStyle(BirchMurnaghan4th(124, 0.01, 4, -5300, -34)),
                 volumes,
                 energies,
             ),
@@ -983,7 +1019,7 @@ end # testset
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(Vinet(124, 0.01, 4, -34)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(Vinet(124, 0.01, 4, -34)), volumes, energies),
             Vinet(
                 124.78343088049905,
                 0.011244915521226076,
@@ -998,12 +1034,12 @@ end # testset
         volumes = data[:, 1] .* u"angstrom^3"
         energies = data[:, 2] .* u"Ry"
         fitted_eos = nonlinfit(
-            BirchMurnaghan3rd(
+            EnergyStyle(BirchMurnaghan3rd(
                 110 * u"angstrom^3",
                 0.01 * u"Ry/angstrom^3",
                 4,
                 -34 * u"Ry",
-            )(Energy()),
+            )),
             volumes,
             energies,
         )
@@ -1018,7 +1054,12 @@ end # testset
         )
         @test _isapprox(
             nonlinfit(
-                BirchMurnaghan3rd(124 * u"angstrom^3", 20 * u"GPa", 4, -17 * u"hartree")(Energy()),
+                EnergyStyle(BirchMurnaghan3rd(
+                    124 * u"angstrom^3",
+                    20 * u"GPa",
+                    4,
+                    -17 * u"hartree",
+                )),
                 volumes,
                 energies,
             ),
@@ -1039,7 +1080,7 @@ end
         volumes = data[:, 1]  # unit: bohr^3
         energies = data[:, 2]  # unit: Rydberg
         @test _isapprox(
-            nonlinfit(Murnaghan(132, 0.01, 3.68, -14)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(Murnaghan(132, 0.01, 3.68, -14)), volumes, energies),
             Murnaghan(
                 132.9174710492377,
                 0.000997071972650323,
@@ -1049,12 +1090,12 @@ end
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(BirchMurnaghan2nd(132, 0.01, -14)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(BirchMurnaghan2nd(132, 0.01, -14)), volumes, energies),
             BirchMurnaghan2nd(130.7191505712864, 0.000706623449967504, -14.817402887854884);
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(BirchMurnaghan3rd(128, 0.03, 4, -14)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(BirchMurnaghan3rd(128, 0.03, 4, -14)), volumes, energies),
             BirchMurnaghan3rd(
                 126.49515516259525,
                 0.0010084167615290376,
@@ -1064,7 +1105,11 @@ end
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(BirchMurnaghan4th(128, 0.03, 4, -320, -14)(Energy()), volumes, energies),
+            nonlinfit(
+                EnergyStyle(BirchMurnaghan4th(128, 0.03, 4, -320, -14)),
+                volumes,
+                energies,
+            ),
             BirchMurnaghan4th(
                 127.67097934611786,
                 0.001041910691949355,
@@ -1075,7 +1120,7 @@ end
             atol = 1e-3,
         )
         @test _isapprox(
-            nonlinfit(Vinet(128, 0.03, 4, -14)(Energy()), volumes, energies),
+            nonlinfit(EnergyStyle(Vinet(128, 0.03, 4, -14)), volumes, energies),
             Vinet(
                 124.71725873851614,
                 0.001064866793589798,
@@ -1090,7 +1135,12 @@ end
         volumes = data[:, 1] .* u"bohr^3"
         energies = data[:, 2] .* u"Ry"
         fitted_eos = nonlinfit(
-            BirchMurnaghan3rd(128 * u"bohr^3", 0.03 * u"Ry/bohr^3", 4, -14 * u"Ry")(Energy()),
+            EnergyStyle(BirchMurnaghan3rd(
+                128 * u"bohr^3",
+                0.03 * u"Ry/bohr^3",
+                4,
+                -14 * u"Ry",
+            )),
             volumes,
             energies,
         )
@@ -1105,7 +1155,12 @@ end
         )
         @test _isapprox(
             nonlinfit(
-                BirchMurnaghan3rd(128 * u"bohr^3", 44 * u"GPa", 4, -14 * u"hartree")(Energy()),
+                EnergyStyle(BirchMurnaghan3rd(
+                    128 * u"bohr^3",
+                    44 * u"GPa",
+                    4,
+                    -14 * u"hartree",
+                )),
                 volumes,
                 energies,
             ),


### PR DESCRIPTION
1. Rename `EquationOfState` to `EOSParameters`, they are parameters, not a whole "EquationOfState"!
2. Add type `EquationOfState`, taking an `EOSParameters` instance and apply on to a volume to get energy, pressure, bulk modulus, etc.
3. Rewrite `nonlinfit` and fix tests